### PR TITLE
CI:fix_certificate_warning

### DIFF
--- a/.github/workflows/compilation_check.yml
+++ b/.github/workflows/compilation_check.yml
@@ -11,9 +11,8 @@ jobs:
         submodules: recursive
     - name: Install toolchain
       run: |
-        wget "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2"
-        tar xvf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
-        echo "$PWD/gcc-arm-none-eabi-9-2019-q4-major/bin" >> $GITHUB_PATH
+        sudo apt update
+        sudo apt install gcc-arm-none-eabi
        
     - name: Build the application
       run: make -C firmware BOARD=m4a-mb


### PR DESCRIPTION
Github actions raises error when building process is trying to download the toolchain from the  arm site.
This change try to install the toolchain from Ubuntu repos.