### PR TITLE
periph: Adds i2c1 to our stm32 board

### DIFF
--- a/boards/stm32f469i-disco/Kconfig
+++ b/boards/stm32f469i-disco/Kconfig
@@ -19,6 +19,7 @@ config BOARD_STM32F469I_DISCO
     select HAS_PERIPH_RTT
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+    select HAS_PERIPH_I2C
     select HAS_PERIPH_USBDEV
 
     # Clock configuration

--- a/boards/stm32f469i-disco/Makefile.features
+++ b/boards/stm32f469i-disco/Makefile.features
@@ -6,5 +6,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_usbdev
 

--- a/boards/stm32f469i-disco/include/periph_conf.h
+++ b/boards/stm32f469i-disco/include/periph_conf.h
@@ -71,7 +71,6 @@ extern "C"
             .dma_chan = UINT8_MAX
 #endif
            },
-           // Alternate Function 8 (AF8)
            // On CN12 connector:        TX -> (PORT_C, 6),   RX -> (PORT_C, 7)
            // On Arduino CN7 connector: TX -> D1(PORT_G, 14),RX -> D0(PORT_G, 9)
            {.dev = USART6,
@@ -92,6 +91,29 @@ extern "C"
 #define UART_1_ISR (isr_usart6)
 
 #define UART_NUMOF ARRAY_SIZE(uart_config)
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    // CN11: i2c1, SDA (PB9), SCL (PB8)
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 8),
+        .sda_pin        = GPIO_PIN(PORT_B, 9),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C1_EV_IRQn,
+    }
+};
+
+#define I2C_0_ISR           isr_i2c1_ev
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 
 #ifdef __cplusplus
 }

--- a/boards/stm32f469i-disco/include/periph_conf.h
+++ b/boards/stm32f469i-disco/include/periph_conf.h
@@ -110,12 +110,12 @@ extern "C"
             .clk = CLOCK_APB1,
             .irqn = I2C1_EV_IRQn,
         },
-        // i2c2 controls the audio DAC(addr: 0x94), Max. speed 100 KHz
+        // i2c2 controls the audio DAC-SAI(addr: 0x94), Max. speed 100 KHz
         {
             .dev = I2C2,
             .speed = I2C_SPEED_NORMAL,
-            .scl_pin = GPIO_PIN(PORT_B, 10),
-            .sda_pin = GPIO_PIN(PORT_B, 11),
+            .scl_pin = GPIO_PIN(PORT_H, 4),
+            .sda_pin = GPIO_PIN(PORT_H, 5),
             .scl_af = GPIO_AF4,
             .sda_af = GPIO_AF4,
             .bus = APB1,

--- a/boards/stm32f469i-disco/include/periph_conf.h
+++ b/boards/stm32f469i-disco/include/periph_conf.h
@@ -53,7 +53,7 @@ extern "C"
 #endif
 
        /**
-        * @name    UART configuration
+        * @brief    UART configuration
         * 
         */
        static const uart_conf_t uart_config[] = {
@@ -93,11 +93,11 @@ extern "C"
 #define UART_NUMOF ARRAY_SIZE(uart_config)
 
 /**
- * @name I2C configuration
- * @{
+ * @brief   I2C configuration
+ * 
  */
 static const i2c_conf_t i2c_config[] = {
-    // CN11: i2c1, SDA (PB9), SCL (PB8)
+    // i2c1 is available on CN11: SDA(PORT_B, 9), SCL(PORT_B, 8)
     {
         .dev            = I2C1,
         .speed          = I2C_SPEED_NORMAL,
@@ -109,6 +109,18 @@ static const i2c_conf_t i2c_config[] = {
         .rcc_mask       = RCC_APB1ENR_I2C1EN,
         .clk            = CLOCK_APB1,
         .irqn           = I2C1_EV_IRQn,
+    },
+    // i2c2 controls the audio DAC(addr: 0x94), Max. speed 100 KHz
+    {
+        .dev            = I2C2,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 10),
+        .sda_pin        = GPIO_PIN(PORT_B, 11),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = RCC_APB1ENR_I2C2EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C2_EV_IRQn
     }
 };
 

--- a/boards/stm32f469i-disco/include/periph_conf.h
+++ b/boards/stm32f469i-disco/include/periph_conf.h
@@ -52,80 +52,82 @@ extern "C"
 {
 #endif
 
-       /**
+    /**
         * @brief    UART configuration
         * 
         */
-       static const uart_conf_t uart_config[] = {
-           // CN1 connector, Virtual Com Port
-           {.dev = USART3,
-            .rcc_mask = RCC_APB1ENR_USART3EN,
-            .rx_pin = GPIO_PIN(PORT_B, 11),
-            .tx_pin = GPIO_PIN(PORT_B, 10),
-            .rx_af = GPIO_AF7,
-            .tx_af = GPIO_AF7,
-            .bus = APB1,
-            .irqn = USART3_IRQn,
+    static const uart_conf_t uart_config[] = {
+        // CN1 connector, Virtual Com Port
+        {.dev = USART3,
+         .rcc_mask = RCC_APB1ENR_USART3EN,
+         .rx_pin = GPIO_PIN(PORT_B, 11),
+         .tx_pin = GPIO_PIN(PORT_B, 10),
+         .rx_af = GPIO_AF7,
+         .tx_af = GPIO_AF7,
+         .bus = APB1,
+         .irqn = USART3_IRQn,
 #ifdef MODULE_PERIPH_DMA
-            .dma_stream = DMA_STREAM_UNDEF,
-            .dma_chan = UINT8_MAX
+         .dma_stream = DMA_STREAM_UNDEF,
+         .dma_chan = UINT8_MAX
 #endif
-           },
-           // On CN12 connector:        TX -> (PORT_C, 6),   RX -> (PORT_C, 7)
-           // On Arduino CN7 connector: TX -> D1(PORT_G, 14),RX -> D0(PORT_G, 9)
-           {.dev = USART6,
-            .rcc_mask = RCC_APB2ENR_USART6EN,
-            .rx_pin = GPIO_PIN(PORT_C, 7),
-            .tx_pin = GPIO_PIN(PORT_C, 6),
-            .rx_af = GPIO_AF8,
-            .tx_af = GPIO_AF8,
-            .bus = APB2,
-            .irqn = USART6_IRQn,
+        },
+        // On CN12 connector:        TX -> (PORT_C, 6),   RX -> (PORT_C, 7)
+        // On Arduino CN7 connector: TX -> D1(PORT_G, 14),RX -> D0(PORT_G, 9)
+        {.dev = USART6,
+         .rcc_mask = RCC_APB2ENR_USART6EN,
+         .rx_pin = GPIO_PIN(PORT_C, 7),
+         .tx_pin = GPIO_PIN(PORT_C, 6),
+         .rx_af = GPIO_AF8,
+         .tx_af = GPIO_AF8,
+         .bus = APB2,
+         .irqn = USART6_IRQn,
 #ifdef MODULE_PERIPH_DMA
-            .dma_stream = DMA_STREAM_UNDEF,
-            .dma_chan = UINT8_MAX
+         .dma_stream = DMA_STREAM_UNDEF,
+         .dma_chan = UINT8_MAX
 #endif
-           }};
+        }};
 
 #define UART_0_ISR (isr_usart3)
 #define UART_1_ISR (isr_usart6)
 
 #define UART_NUMOF ARRAY_SIZE(uart_config)
 
-/**
- * @brief   I2C configuration
- * 
- */
-static const i2c_conf_t i2c_config[] = {
-    // i2c1 is available on CN11: SDA(PORT_B, 9), SCL(PORT_B, 8)
-    {
-        .dev            = I2C1,
-        .speed          = I2C_SPEED_NORMAL,
-        .scl_pin        = GPIO_PIN(PORT_B, 8),
-        .sda_pin        = GPIO_PIN(PORT_B, 9),
-        .scl_af         = GPIO_AF4,
-        .sda_af         = GPIO_AF4,
-        .bus            = APB1,
-        .rcc_mask       = RCC_APB1ENR_I2C1EN,
-        .clk            = CLOCK_APB1,
-        .irqn           = I2C1_EV_IRQn,
-    },
-    // i2c2 controls the audio DAC(addr: 0x94), Max. speed 100 KHz
-    {
-        .dev            = I2C2,
-        .speed          = I2C_SPEED_NORMAL,
-        .scl_pin        = GPIO_PIN(PORT_B, 10),
-        .sda_pin        = GPIO_PIN(PORT_B, 11),
-        .scl_af         = GPIO_AF4,
-        .sda_af         = GPIO_AF4,
-        .bus            = RCC_APB1ENR_I2C2EN,
-        .clk            = CLOCK_APB1,
-        .irqn           = I2C2_EV_IRQn
-    }
-};
+    /**
+     * @brief   I2C configuration
+     * 
+     */
+    static const i2c_conf_t i2c_config[] = {
+        // i2c1 is available on CN11: SDA(PORT_B, 9), SCL(PORT_B, 8)
+        {
+            .dev = I2C1,
+            .speed = I2C_SPEED_NORMAL,
+            .scl_pin = GPIO_PIN(PORT_B, 8),
+            .sda_pin = GPIO_PIN(PORT_B, 9),
+            .scl_af = GPIO_AF4,
+            .sda_af = GPIO_AF4,
+            .bus = APB1,
+            .rcc_mask = RCC_APB1ENR_I2C1EN,
+            .clk = CLOCK_APB1,
+            .irqn = I2C1_EV_IRQn,
+        },
+        // i2c2 controls the audio DAC(addr: 0x94), Max. speed 100 KHz
+        {
+            .dev = I2C2,
+            .speed = I2C_SPEED_NORMAL,
+            .scl_pin = GPIO_PIN(PORT_B, 10),
+            .sda_pin = GPIO_PIN(PORT_B, 11),
+            .scl_af = GPIO_AF4,
+            .sda_af = GPIO_AF4,
+            .bus = APB1,
+            .rcc_mask = RCC_APB1ENR_I2C2EN,
+            .clk = CLOCK_APB1,
+            .irqn = I2C2_EV_IRQn,
+        }};
 
-#define I2C_0_ISR           isr_i2c1_ev
-#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+#define I2C_0_ISR isr_i2c1_ev
+#define I2C_1_ISR isr_i2c2_ev
+
+#define I2C_NUMOF ARRAY_SIZE(i2c_config)
 
 #ifdef __cplusplus
 }

--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -13,8 +13,8 @@ ifneq (,$(filter tests_driver_%,$(APPLICATION)))
 endif
 
 BOARD ?= m4a-mb
-RIOTBASE ?= $(CURDIR)/../RIOT
-QUIET ?= 1
 
-# DEVELHELP enabled by default for all tests, set 0 to disable
+RIOTBASE ?= $(CURDIR)/../RIOT
+
+QUIET ?= 1
 DEVELHELP ?= 1

--- a/tests/board_stm32f469i-disco/Makefile
+++ b/tests/board_stm32f469i-disco/Makefile
@@ -13,11 +13,12 @@ RIOTBASE ?= $(CURDIR)/../../RIOT
 # Custom boards "MUST BE" into "boards" folder, it's code **strongly** hardware dependent
 EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../boards
 
-USEMODULE += ps
+USEMODULE += xtimer
 USEMODULE += shell
 USEMODULE += shell_commands
-USEMODULE += xtimer
 USEMODULE += saul_default
+
+FEATURES_REQUIRED += periph_i2c
 
 DEVHELP ?= 1
 QUIET ?= 1

--- a/tests/driver_epd-bw-spi/Makefile
+++ b/tests/driver_epd-bw-spi/Makefile
@@ -1,10 +1,8 @@
-APPLICATION = driver_epd_bw_spi
+APPLICATION = test_driver_epd_bw_spi
 BOARD ?= m4a-mb
 
 APPBASE ?= $(CURDIR)
-
 RIOTBASE ?= $(CURDIR)/../../RIOT
-
 EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../boards
 
 DEVHELP ?= 1

--- a/tests/driver_mpu9x50/Makefile
+++ b/tests/driver_mpu9x50/Makefile
@@ -16,10 +16,7 @@ QUIET ?= 1
 USEMODULE += xtimer
 USEMODULE += shell
 USEMODULE += shell_commands
-#USEMODULE += mpu9150
+USEMODULE += mpu9150
 USEMODULE += saul_default
-FEATURES_REQUIRED += periph_gpio
-#FEATURES_REQUIRED += periph_i2c
-
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mpu9x50/Makefile
+++ b/tests/driver_mpu9x50/Makefile
@@ -1,0 +1,25 @@
+APPLICATION = test_mpu9150
+BOARD ?= m4a-mb
+
+# Current path
+APPBASE ?= $(CURDIR)
+
+# RIOT-OS's base path
+RIOTBASE ?= $(CURDIR)/../../RIOT
+
+# Custom boards "MUST BE" into "boards" folder, it's code **strongly** hardware dependent
+EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../boards
+
+DEVHELP ?= 1
+QUIET ?= 1
+
+USEMODULE += xtimer
+USEMODULE += shell
+USEMODULE += shell_commands
+#USEMODULE += mpu9150
+USEMODULE += saul_default
+FEATURES_REQUIRED += periph_gpio
+#FEATURES_REQUIRED += periph_i2c
+
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mpu9x50/README.md
+++ b/tests/driver_mpu9x50/README.md
@@ -1,0 +1,13 @@
+# About
+This is a test application for the MPU-9X50 (MPU9150 and MPU9250) Nine-Axis Driver.
+
+# Usage
+The application will initialize the MPU-9X50 (MPU9150 and MPU9250) motion sensor with the following parameters:
+ - Accelerometer: ON
+ - Gyroscope: ON
+ - Magnetometer: ON
+ - Sampling Rate: 200Hz
+ - Compass Sampling Rate: 100Hz
+
+After initialization, the application reads accel, gyro, compass and temperature values
+every second and prints them to the STDOUT.

--- a/tests/driver_mpu9x50/main.c
+++ b/tests/driver_mpu9x50/main.c
@@ -1,0 +1,47 @@
+/* 
+ * Copyright (c) 2021 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file main.c
+ * @author luisan00 (luisan00@hotmail.com)
+ * @brief test driver mpu9x50 (NO INT)
+ * @version 0.1
+ * @date 2021-09-25
+ * 
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "shell.h"
+#include "shell_commands.h"
+#include "msg.h"
+
+#include "log.h"
+
+static const shell_command_t shell_commands[] = {
+    {NULL, NULL, NULL}};
+
+int main(void)
+{
+    puts("Welcome to RIOT!");
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
## Contribution description
This contribution adds periph i2c to our stm32 board

## Testing procedure

Compile and flash the example ; `driver_u8g2`


