### PR TITLE
ci: Fix Codespell Doxygen

### DIFF
--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -10,7 +10,7 @@ CODESPELL_OPT=" -c"
 CODESPELL_OPT+=" -q 2"
 CODESPELL_OPT+=" --check-hidden"
 CODESPELL_OPT+=" --ignore-words ${TOOLS}/codespell/ignored_words.txt"
-CODESPELL_OPT+=" --skip=RIOT,dist,.git,doc/doxygen/html"
+CODESPELL_OPT+=" --skip=RIOT,dist,.git,doc/doxygen/html,js,m4a.doxyfile"
 ERRORS=$(${CODESPELL_CMD} ${CODESPELL_OPT})
 
 if [ -n "${ERRORS}" ]


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description
This PR is dedicated to resolve the issues from codespell static-test. We want to ignore the doxygen docs to resolve this


### Testing procedure

General static-tests in the first directory m4a-firmware
```sh
make static-test
```

Using the local static test
```sh
cd dist/tools/codespell
./check.sh
```


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
