### PR TITLE
Update .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ steps:
     privileged: true
     commands:
       - git submodule update --init --recursive
-      - make -C firmware BOARD=m4a-rover
+      - make -C firmware BOARD=m4a-wrover
 
   - name: build-m4a-wroom
     image: luisan00/m4abuild-base:latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,27 +4,27 @@ type: docker
 
 steps:
   - name: build-m4a-24g
-    image: luisan00/m4abuild-base:dev
+    image: luisan00/m4abuild-base:latest
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=m4a-24g
 
   - name: build-m4a-mb
-    image: luisan00/m4abuild-base:dev
+    image: luisan00/m4abuild-base:latest
     privileged: true
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=m4a-mb
 
   - name: build-m4a-wrover
-    image: luisan00/m4abuild-base:dev
+    image: luisan00/m4abuild-base:latest
     privileged: true
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=m4a-wrover
 
   - name: build-m4a-wroom
-    image: luisan00/m4abuild-base:dev
+    image: luisan00/m4abuild-base:latest
     privileged: true
     commands:
       - git submodule update --init --recursive

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,27 +4,27 @@ type: docker
 
 steps:
   - name: build-m4a-24g
-    image: luisan00/m4abuild-base:latest
+    image: luisan00/m4abuild-base:dev
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=m4a-24g
 
   - name: build-m4a-mb
-    image: luisan00/m4abuild-base:latest
+    image: luisan00/m4abuild-base:dev
     privileged: true
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=m4a-mb
 
   - name: build-m4a-wrover
-    image: luisan00/m4abuild-base:latest
+    image: luisan00/m4abuild-base:dev
     privileged: true
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=m4a-wrover
 
   - name: build-m4a-wroom
-    image: luisan00/m4abuild-base:latest
+    image: luisan00/m4abuild-base:dev
     privileged: true
     commands:
       - git submodule update --init --recursive

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,12 +21,14 @@ steps:
     privileged: true
     commands:
       - git submodule update --init --recursive
+      - make -C firmware BOARD=m4a-rover
 
   - name: build-m4a-wroom
     image: luisan00/m4abuild-base:latest
     privileged: true
     commands:
       - git submodule update --init --recursive
+      - make -C firmware BOARD=m4a-wroom
 
 trigger:
   event:


### PR DESCRIPTION
### Contribution description
Latest point of the issue #72 (CI integration):
- updated and published docker image on dockerhub
- add support for esp32 boards

### Testing procedure

Luke should be happy

### Update

Taken from: https://ci.mesh4all.org/Mesh4all/m4a-firmware/131

#### Builds summary

`build-m4a-24g`:
```sh
...
"make" -C /drone/src/firmware/sys/system_init
   text	   data	    bss	    dec	    hex	filename
 103004	    144	  23408	 126556	  1ee5c	/drone/src/firmware/bin/m4a-24g/m4a-mesh.elf
``` 
`build-m4a-mb`:
```sh
...
"make" -C /drone/src/firmware/sys/system_init
   text	   data	    bss	    dec	    hex	filename
 103196	    144	  23448	 126788	  1ef44	/drone/src/firmware/bin/m4a-mb/m4a-mesh.elf
```
`build-m4a-wrover`:
```sh
...
"make" -C /drone/src/firmware/sys/system_init
esptool.py v2.4.0
Parsing CSV input...
   text	   data	    bss	    dec	    hex	filename
 386264	  61684	  52016	 499964	  7a0fc	/drone/src/firmware/bin/m4a-wrover/m4a-mesh.elf
```
`build-m4a-wroom`:
```sh
...
"make" -C /drone/src/firmware/sys/system_init
esptool.py v2.4.0
Parsing CSV input...
   text	   data	    bss	    dec	    hex	filename
 386080	  61748	  51984	 499812	  7a064	/drone/src/firmware/bin/m4a-wroom/m4a-mesh.elf
```

### Issues/PRs references
Fxes #72 