### PR TITLE
wifi-subsys: async uart implementation

### DIFF
--- a/wifi-subsys/components/uart/CMakeLists.txt
+++ b/wifi-subsys/components/uart/CMakeLists.txt
@@ -1,0 +1,2 @@
+file(GLOB_RECURSE SOURCES src/*.c)
+idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS src ../../main )

--- a/wifi-subsys/components/uart/src/subsys_uart.c
+++ b/wifi-subsys/components/uart/src/subsys_uart.c
@@ -1,0 +1,236 @@
+#include <string.h>
+#include "esp_log.h"
+#include "driver/uart.h"
+#include "driver/gpio.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "subsys_uart.h"
+
+static const char *TAG = "subsys_uart";
+static const int RX_BUF_SIZE = 1024;
+
+#define ARRAY_SIZE  11
+
+#define TXD_PIN (GPIO_NUM_10)
+#define RXD_PIN (GPIO_NUM_9)
+
+/** this are commands for tests this will be removed in the future */
+char *COMMAND[11] = {"AT+WAP_SSID=kevin","AT+WAP_PASS=hiiii",
+                    "AT+WSTA_SSID=new_ssid", "AT+WSTA_PASS=new_passoword",
+                    "AT+WIFI_OFF", "AT+WIFI_ON", "AT+NVS_RST", "AT+WIFI_MODE=1",
+                    "AT+WAP_CHAN=1", "AT+WAP_AUTH=1", "AT+WIFI_RST"};
+
+char *default_keys[ARRAY_SIZE] = {
+    "NVS_RST", "WIFI_OFF", "WAP_SSID", "WAP_PASS",
+    "WAP_CHAN", "WAP_AUTH", "WIFI_ON",  "WIFI_MODE",
+    "WIFI_RST", "WSTA_SSID", "WSTA_PASS",
+};
+
+esp_err_t setting_uart(void)
+{
+    esp_err_t err;
+    const uart_config_t uart_config = {
+        .baud_rate = 115200,
+        .data_bits = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .source_clk = UART_SCLK_APB,
+    };
+    // We won't use a buffer for sending data.
+    err = uart_driver_install(UART_NUM_1, RX_BUF_SIZE * 2, 0, 0, NULL, 0);
+    if(err != ESP_OK) {
+        return err;
+    }
+    err = uart_param_config(UART_NUM_1, &uart_config);
+    if(err != ESP_OK) {
+        return err;
+    }
+    err = uart_set_pin(UART_NUM_1, TXD_PIN, RXD_PIN, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    if(err != ESP_OK) {
+        return err;
+    }
+
+    return ESP_OK;
+}
+
+int sendData(const char* logName, char* data)
+{
+    const int len = strlen(data);
+    printf("before send %s \n", data);
+    const int txBytes = uart_write_bytes(UART_NUM_1, data, len);
+    ESP_LOGI(logName, "Wrote %d bytes", txBytes);
+    return txBytes;
+}
+
+esp_err_t parse_at_message(uint8_t* at_comant, at_request_t* output)
+{
+    char* commands = (char*)at_comant;
+    char *key = strtok(commands, "+");
+    char firts_step[100];
+    char* key_value = NULL;
+    char* value = NULL;
+
+    int i = 0;
+    while( key != NULL ) {
+      if(i == 1){
+        memcpy(firts_step, key, sizeof(firts_step));
+      }
+      i++;
+
+      key = strtok(NULL, "+");
+    }
+
+    char *key2 = strtok(firts_step, "=");
+    i = 0;
+    while( key2 != NULL ) {
+      if(i == 0){
+        key_value = (char *) malloc(strlen(key2) +1);
+
+        memset(key_value, 0, strlen(key2)+ 1);
+        memcpy(key_value, key2, strlen(key2) + 1);
+      }
+      if(i == 1){
+        value = (char *) malloc(strlen(key2) +1);
+        memcpy(value, key2, strlen(key2) +1);
+      }
+      i++;
+      key2 = strtok(NULL, "+");
+    }
+
+    /* cppcheck-suppress nullPointerRedundantCheck
+    * (reason: <is necessary verify that this data is not null>) */
+    memcpy(&output->key, key_value, strlen(key_value) +1);
+    if (value != NULL) {
+        memcpy(&output->value, value, strlen(value) + 1);
+    }
+
+    if(key_value == NULL && value == NULL ){
+        return ESP_FAIL;
+    }
+
+    free(value);
+    free(key_value);
+
+    return ESP_OK;
+}
+
+int at_cmd_to_name (char* key)
+{
+    for (size_t i = 0; i < ARRAY_SIZE; i++)
+    {
+        if (strcmp(default_keys[i], key) == 0){
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+void at_handler(uint8_t* at_comant)
+{
+    char* commands = (char*)at_comant;
+    at_request_t payload;
+
+    payload.key = malloc(32);
+    payload.value = malloc(32);
+    parse_at_message(at_comant, &payload);
+
+    enum at_keys_n at_key = at_cmd_to_name(payload.key);
+
+    switch (at_key)
+    {
+    case (NVS_RST):
+        printf("nvs rst \n");
+        break;
+    case (WIFI_OFF):
+        printf("wifi off \n");
+        break;
+    case (WAP_SSID):
+        printf("wifi_wap_ssid \n");
+        break;
+    case (WAP_PASS):
+        printf("wifi_wap_pass \n");
+         break;
+    case (WAP_CHAN):
+        printf("wifi_wap_ch \n");
+         break;
+    case (WAP_AUTH):
+        printf("wifi_wap_auth \n");
+        break;
+    case (WIFI_ON):
+        printf("wifi_on \n");
+        break;
+    case (WIFI_MODE):
+        printf("wifi_mode \n");
+        break;
+    case (WIFI_RST):
+        printf("wifi_rst \n");
+        break;
+    case (WSTA_SSID):
+        printf("wifi_wsta_ssid \n");
+        break;
+    case (WSTA_PASS):
+        printf("wifi_wsta_pass \n");
+        break;
+    default:
+        printf("unhandler event %i \n", at_key);
+        break;
+    }
+    ESP_LOGI(TAG, "KEY: '%s' ", payload.key);
+
+    free(payload.key);
+    free(payload.value);
+
+}
+
+void received_sensor_data (uint8_t* values)
+{
+    char* message = (char*)values;
+    ESP_LOGI(TAG, "Read sensor data: '%s' ", message);
+}
+
+void tx_send_loop(void *arg)
+{
+    static const char *TX_TASK_TAG = "TX_TASK";
+    esp_log_level_set(TX_TASK_TAG, ESP_LOG_INFO);
+    int counter = 0;
+    while (1) {
+        if(counter == 4){
+            counter = 0;
+        } else {
+            counter = counter + 1;
+        }
+        sendData(TX_TASK_TAG, COMMAND[counter]);
+        vTaskDelay(2000 / portTICK_PERIOD_MS);
+    }
+}
+
+void rx_receive(void *arg)
+{
+    esp_log_level_set(TAG, ESP_LOG_INFO);
+    uint8_t* data = (uint8_t*) malloc(RX_BUF_SIZE+1);
+    while (1) {
+        const int rxBytes = uart_read_bytes(UART_NUM_1, data, RX_BUF_SIZE, 1000 / portTICK_RATE_MS);
+        if (rxBytes > 0) {
+            data[rxBytes] = 0;
+            if(rxBytes > 2 && data[0] == 0x41 && data[1] == 0x54 && data[2] == 0x2b){
+                at_handler(data);
+            } else {
+                received_sensor_data(data);
+            }
+            ESP_LOG_BUFFER_HEXDUMP(TAG, data, rxBytes, ESP_LOG_INFO);
+        }
+    }
+    free(data);
+}
+
+esp_err_t init_uart()
+{
+    esp_err_t err = setting_uart();
+    if(err != ESP_OK) {
+        return err;
+    }
+    xTaskCreate(rx_receive, "uart_rx_task", 1024*2, NULL, configMAX_PRIORITIES, NULL);
+    return ESP_OK;
+}

--- a/wifi-subsys/components/uart/src/subsys_uart.h
+++ b/wifi-subsys/components/uart/src/subsys_uart.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @brief       uart module
+ *
+ * @copyright   Copyright (c) 2021 Mesh for all
+ * @author      xkevin190 <kevinvelasco193@gmail.com>
+ *
+ */
+#ifndef SUBSYS_UART_H
+#define SUBSYS_UART_H
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+/**
+ * @brief this struct content the key and value of the AT request
+ *
+ */
+typedef struct {
+    char *value; /*!< AT value */
+    char *key;   /*!< AT key */
+} at_request_t;
+
+enum at_keys_n {
+    NVS_RST = 0,  /*!< Restore the subsystem to factory settings */
+    WIFI_OFF,     /*!< Turn off the WiFi interface */
+    WAP_SSID,     /*!< Set the AP SSID */
+    WAP_PASS,     /*!< Set the AP password */
+    WAP_CHAN,     /*!< Sets the AP channel */
+    WAP_AUTH,     /*!< Sets the authentication type */
+    WIFI_ON,      /*!< Turn on the WiFi interface */
+    WIFI_MODE,    /*!< Sets the WiFi mode to None / AP / STA / AP+STA */
+    WIFI_RST,     /*!< Restore the subsystem to factory settings */
+    WSTA_SSID,    /*!< Set the STA SSID */
+    WSTA_PASS,    /*!< Set the STA password */
+};
+
+/**
+ * @brief this function initialize the uart
+ * and init the event loop where will be received messages.
+ *
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t init_uart();
+
+/**
+ * @brief this function is executed when arrived a new mensajes
+ * a through uart rx, here identify if is an AT command or sensors data.
+ *
+ */
+void rx_receive();
+
+/**
+ * @brief is one loop for send messages every  2 seconds
+ * this function was created for send AT commands for testing
+ *
+ */
+void tx_send_loop();
+/**
+ * @brief this function is executed when rx_receive function identify
+ *  that the datos arrived were sensors values.
+ *
+ *  @param values [in] sensor values
+ */
+void received_sensor_data(uint8_t* values);
+
+/**
+ * @brief this function is a handler where will be identified AT commands
+ * and it will executed  the functions for controlled  the wifi.
+ *
+ * @param at_comant [in] AT comands
+ */
+void at_handler(uint8_t* at_comant);
+/**
+ * @brief this function send the bytes through uart tx
+ *
+ * @return int  will be returned  the number of bytes sent
+ */
+int sendData();
+
+/**
+ * @brief in this function is added  the gpios
+ * the baudrate  and set all the uart settings
+ *
+ */
+esp_err_t setting_uart();
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* SUBSYS_UART_H */

--- a/wifi-subsys/components/uart/test/CMakeLists.txt
+++ b/wifi-subsys/components/uart/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRC_DIRS "."
+                       INCLUDE_DIRS "."
+                       REQUIRES uart unity)

--- a/wifi-subsys/components/uart/test/uart_test.c
+++ b/wifi-subsys/components/uart/test/uart_test.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "unity.h"
+#include "subsys_uart.h"
+#include "esp_err.h"
+
+TEST_CASE("uart initialize", "[UART]")
+{
+    esp_err_t err;
+
+    err = init_uart();
+
+    if (err != ESP_OK) TEST_FAIL();
+}
+
+TEST_CASE("send uart bytes", "[UART]")
+{
+    const char* test = "test_data";
+    int byteslen = sendData("uart_test", test);
+
+    if(byteslen == 0) TEST_FAIL();
+}


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

simple async uart implementation for use with AT commands and could receive sensor datos for send to the cloud.

This is an initial implementation for the communication between the boards throw uart protocol.

### testing procedure

`cd test && idf.py build -D "TEST_COMPONENTS=uart" flash monitor`

```sh
Here's the test menu, pick your combo:
(1)	"uart initialize" [UART]
(2)	"send uart bytes" [UART]
```
this PR fixes #116 