### PR TITLE
Codespell ignores directory wifi-subsys/build

### DIFF
--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -10,7 +10,7 @@ CODESPELL_OPT=" -c"
 CODESPELL_OPT+=" -q 2"
 CODESPELL_OPT+=" --check-hidden"
 CODESPELL_OPT+=" --ignore-words ${TOOLS}/codespell/ignored_words.txt"
-CODESPELL_OPT+=" --skip=RIOT,dist,.git,css,html,js,m4a.doxyfile"
+CODESPELL_OPT+=" --skip=RIOT,dist,./wifi-subsys/build,.git,css,html,js,m4a.doxyfile"
 ERRORS=$(${CODESPELL_CMD} ${CODESPELL_OPT})
 
 if [ -n "${ERRORS}" ]


### PR DESCRIPTION
<!--

We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description
 
If we run the static-test codespell be ignored the directory wifi-subsys/build and that fixes Issue #120 Codespell,

<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure

<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->
look at  dist/tools/codespell/check.sh was added "CODESPELL_OPT+=" --skip=RIOT,dist,./wifi-subsys/build,.git,css,html,js,m4a.doxyfile" "
### Issues/PRs references
fixes  #120

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
