### PR TITLE
AT and NVS integration 

### DIFF
--- a/wifi-subsys/.gitignore
+++ b/wifi-subsys/.gitignore
@@ -1,3 +1,5 @@
 sdkconfig
 sdkconfig.old
 dev-config.h
+managed_components/
+dependencies.lock

--- a/wifi-subsys/components/network/src/wifi.c
+++ b/wifi-subsys/components/network/src/wifi.c
@@ -31,8 +31,6 @@
 #include "storage.h"
 #include "default_params.h"
 
-static const char *TAG = "Wifi Module";
-
 static int s_retry_num = 0;
 
 static void event_handler(void *arg, esp_event_base_t event_base,
@@ -49,14 +47,14 @@ static void event_handler(void *arg, esp_event_base_t event_base,
         {
             esp_wifi_connect();
             s_retry_num++;
-            ESP_LOGI(TAG, "retry to connect to the AP");
+            ESP_LOGI(__func__, "retry to connect to the AP");
         }
-        ESP_LOGI(TAG, "connect to the AP fail");
+        ESP_LOGI(__func__, "connect to the AP fail");
     }
     else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP)
     {
         ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
-        ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
+        ESP_LOGI(__func__, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
         s_retry_num = 0;
     }
 
@@ -64,22 +62,47 @@ static void event_handler(void *arg, esp_event_base_t event_base,
     if (event_id == WIFI_EVENT_AP_STACONNECTED)
     {
         wifi_event_ap_staconnected_t *event = (wifi_event_ap_staconnected_t *)event_data;
-        ESP_LOGI(TAG, "station " MACSTR " join, AID=%d",
+        ESP_LOGI(__func__, "station " MACSTR " join, AID=%d",
                  MAC2STR(event->mac), event->aid);
     }
     else if (event_id == WIFI_EVENT_AP_STADISCONNECTED)
     {
         wifi_event_ap_stadisconnected_t *event = (wifi_event_ap_stadisconnected_t *)event_data;
-        ESP_LOGI(TAG, "station " MACSTR " leave, AID=%d", MAC2STR(event->mac), event->aid);
+        ESP_LOGI(__func__, "station " MACSTR " leave, AID=%d", MAC2STR(event->mac), event->aid);
     }
 }
 
 esp_err_t init_sta(void)
 {
+    esp_err_t err;
     wifi_config_t sta_config;
     memset(&sta_config, 0, sizeof(wifi_config_t));
-    memcpy(sta_config.sta.ssid, WSTA_SSID, sizeof(WSTA_SSID));
-    memcpy(sta_config.sta.password, WSTA_PASS, sizeof(WSTA_PASS));
+    size_t ssid_len = 0;
+    size_t password_len = 0;
+
+    err = nvs_get_string(stringlify(WSTA),
+                        stringlify(WSTA_SSID),
+                        &sta_config.sta.ssid,
+                        &ssid_len);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__,
+                 "Error to the get sta password (%s)",
+                 esp_err_to_name(err));
+        return err;
+    }
+
+    err = nvs_get_string(stringlify(WSTA),
+                        stringlify(WSTA_PASS),
+                        &sta_config.sta.password,
+                        &password_len);
+
+    if(err != ESP_OK) {
+         ESP_LOGE(__func__,
+                 "Error to the get sta password (%s)",
+                 esp_err_to_name(err));
+        return err;
+    }
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &sta_config));
     ESP_ERROR_CHECK(esp_wifi_start());
@@ -91,9 +114,8 @@ int is_sta()
 {
     wifi_mode_t mode;
     esp_err_t err = esp_wifi_get_mode(&mode);
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "esp_wifi_get_mode failed (%s)", esp_err_to_name(err));
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "esp_wifi_get_mode failed (%s)", esp_err_to_name(err));
         return 0;
     }
 
@@ -109,14 +131,12 @@ int is_ap()
 {
     wifi_mode_t mode;
     esp_err_t err = esp_wifi_get_mode(&mode);
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "esp_wifi_get_mode failed (%s)", esp_err_to_name(err));
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "esp_wifi_get_mode failed (%s)", esp_err_to_name(err));
         return 0;
     }
 
-    if (mode == WIFI_MODE_AP)
-    {
+    if (mode == WIFI_MODE_AP) {
         return 1;
     }
 
@@ -127,36 +147,91 @@ esp_err_t init_ap(void)
 {
     wifi_config_t wifi_config;
     esp_err_t err;
+    size_t ssid_len = 0;
+    size_t password_len = 0;
 
     memset(&wifi_config, 0, sizeof(wifi_config_t));
 
-    memcpy(&wifi_config.ap.ssid, WAP_SSID, sizeof(WAP_SSID));
-    memcpy(&wifi_config.ap.password, WAP_PASS, sizeof(WAP_PASS));
-    wifi_config.ap.ssid_len = strlen(WAP_SSID);
-    wifi_config.ap.authmode = WAP_AUTH;
-    wifi_config.ap.max_connection = WAP_MAXCON;
-    wifi_config.ap.channel = WAP_CHAN;
+    err = nvs_get_string(stringlify(WAP),
+                        stringlify(WAP_SSID),
+                        &wifi_config.ap.ssid,
+                        &ssid_len);
 
-    if (strlen(WAP_PASS) == 0)
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "error to get WAP SSID the cause is %s", esp_err_to_name(err));
+        return err;
+    }
+
+    err = nvs_get_string(stringlify(WAP),
+                        stringlify(WAP_PASS),
+                        &wifi_config.sta.password,
+                        &password_len);
+
+    if(err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "error to get WAP PASSWORD the cause is %s",
+                esp_err_to_name(err));
+        return err;
+    }
+
+    err = nvs_get_uint8(stringlify(WAP),
+                        stringlify(WAP_MAXCON),
+                        &wifi_config.ap.max_connection);
+    if(err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "error to get max_connections the cause is %s",
+                esp_err_to_name(err));
+
+        return err;
+    }
+
+    err = nvs_get_uint8(stringlify(WAP),
+                          stringlify(WAP_CHAN),
+                        &wifi_config.ap.channel);
+    if(err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "error to get AP channel the cause is %s",
+                esp_err_to_name(err));
+        return err;
+    }
+
+    wifi_config.ap.ssid_len = ssid_len;
+
+    if (password_len == 0)
     {
         wifi_config.ap.authmode = WIFI_AUTH_OPEN;
     }
+    else {
+        err = nvs_get_uint8(stringlify(WAP),
+                        stringlify(WAP_AUTH),
+                        &wifi_config.ap.authmode);
+
+        if(err != ESP_OK) {
+            ESP_LOGE(__func__,
+                "error to get ap auth mode the cause is %s",
+                esp_err_to_name(err));
+            return err;
+        }
+    }
 
     err = esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "Error: to setting ap config");
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "error to the set wifi mode the cause is %s",
+                esp_err_to_name(err));
         return err;
     }
     err = esp_wifi_start();
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "Starting the Access Point");
+
+    if (err != ESP_OK) {
+         ESP_LOGE(__func__,
+                "error to start the wifi, the cause is %s",
+                esp_err_to_name(err));
         return err;
     }
 
-    ESP_LOGI(TAG, "WiFi SOFTAP finished. SSID:%s password:%s channel:%d",
-             wifi_config.ap.ssid, wifi_config.ap.password, WAP_CHAN);
+    ESP_LOGI(__func__, "WiFi SOFTAP finished. SSID:%s password:%s channel:%d",
+             wifi_config.ap.ssid, wifi_config.ap.password, wifi_config.ap.channel);
 
     return ESP_OK;
 }
@@ -165,15 +240,30 @@ uint8_t wifi_credentials_are_configured()
 {
     uint8_t is_configured = 0;
 
-    esp_err_t err = nvs_get_uint8(stringlify(NVS), NVS_IS_INIT, &is_configured);
+    esp_err_t err = nvs_get_uint8(stringlify(NVS),
+                                  stringlify(NVS_IS_INIT),
+                                  &is_configured);
 
     if (err != ESP_OK)
     {
-        ESP_LOGE(TAG, "It seems that WiFi is not configured yet, setting defaults parameters");
+        ESP_LOGE(__func__, "It seems that WiFi is not configured yet, setting defaults parameters");
         return 0;
     }
 
     return is_configured;
+}
+
+int identify_enabled_interface (void)
+{
+#if WSTA_ENABLED && WAP_ENABLED
+    return WIFI_MODE_APSTA;
+#elif WAP_ENABLED
+    return WIFI_MODE_AP;
+#elif WSTA_ENABLED
+    return WIFI_MODE_STA;
+#else
+    return 0;
+#endif
 }
 
 esp_err_t set_default_credentials(void)
@@ -181,35 +271,73 @@ esp_err_t set_default_credentials(void)
     esp_err_t err = nvs_set_string(stringlify(WAP), stringlify(WAP_SSID), WAP_SSID);
     if (err != ESP_OK)
     {
-        ESP_LOGE(TAG, "Error: to setting AP SSID to the nvs");
+        ESP_LOGE(__func__,
+                "Error: to setting AP SSID to the nvs %s",
+                esp_err_to_name(err));
     }
 
     err = nvs_set_string(stringlify(WAP), stringlify(WAP_PASS), WAP_PASS);
     if (err != ESP_OK)
     {
-        ESP_LOGE(TAG, "Error: to setting AP Password to the nvs");
+        ESP_LOGE(__func__,
+                "Error: to setting AP Password to the nvs %s",
+                esp_err_to_name(err));
     }
 
     err = nvs_set_string(stringlify(WSTA), stringlify(WSTA_SSID), WSTA_SSID);
     if (err != ESP_OK)
     {
-        ESP_LOGE(TAG, "Error: to settin STA password to the nvs");
+        ESP_LOGE(__func__,
+                "Error: to setting STA ssid to the nvs %s",
+                esp_err_to_name(err));
     }
 
     err = nvs_set_string(stringlify(WSTA), stringlify(WSTA_PASS), WSTA_PASS);
     if (err != ESP_OK)
     {
-        ESP_LOGE(TAG, "Error: to setting STA password to the nvs");
+        ESP_LOGE(__func__,
+                "Error: to setting STA password to the nvs %s",
+                esp_err_to_name(err));
     }
-    /* cppcheck-suppress duplicateCondition
-    * (reason: <your reason why you think this is a false positive>) */
+
+    err = nvs_set_uint8(stringlify(WAP), stringlify(WAP_CHAN), WAP_CHAN);
     if (err != ESP_OK)
     {
+        ESP_LOGE(__func__,
+                "Error: to setting WAP channel to the nvs %s",
+                esp_err_to_name(err));
+    }
+
+    err = nvs_set_uint8(stringlify(WAP), stringlify(WAP_MAXCON), WAP_MAXCON);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(__func__,
+                "Error: to setting AP max connections to the nvs %s",
+                esp_err_to_name(err));
+    }
+
+    err = nvs_set_uint8(stringlify(WAP), stringlify(WAP_AUTH),WAP_AUTH);
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to setting AP auth to the nvs %s",
+                esp_err_to_name(err));
+    }
+    err = nvs_set_uint8(stringlify(WIFI),
+                        stringlify(WIFI_MODE),
+                        identify_enabled_interface());
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to setting WIFI mode to the nvs %s",
+                esp_err_to_name(err));
+    }
+    /* cppcheck-suppress duplicateCondition
+    * (reason: <is necessary because all function executed before,
+    needed response ESP_OK for save the nvs configuration in true>) */
+    if (err != ESP_OK) {
         nvs_set_uint8(stringlify(NVS), stringlify(NVS_IS_INIT), 0);
         return err;
     }
-    else
-    {
+    else {
         nvs_set_uint8(stringlify(NVS), stringlify(NVS_IS_INIT), 1);
         return ESP_OK;
     }
@@ -217,14 +345,320 @@ esp_err_t set_default_credentials(void)
     return ESP_OK;
 }
 
+esp_err_t wifi_on(void)
+{
+  esp_err_t err =  wifi_init();
+  if (err != ESP_OK) {
+      ESP_LOGE(__func__,
+                "Error: to the init wifi %s",
+                esp_err_to_name(err));
+      return err;
+  }
+  return ESP_OK;
+}
+
+esp_err_t wifi_off(void)
+{
+   esp_err_t err = esp_wifi_stop();
+   if(err != ESP_OK) {
+          ESP_LOGE(__func__,
+                "Error: to  the turn off the wifi %s",
+                esp_err_to_name(err));
+       return err;
+   }
+   return ESP_OK;
+}
+
+esp_err_t wifi_restart(void)
+{
+    esp_err_t err;
+    err = wifi_off();
+    if(err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to the turn off the wifi %s",
+                esp_err_to_name(err));
+        return err;
+    }
+    err = wifi_on();
+    if(err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to start the wifi %s",
+                esp_err_to_name(err));
+        return err;
+    }
+    return ESP_OK;
+}
+
+esp_err_t change_wifi_sta_ssid (char* sta_ssid)
+{
+    esp_err_t err;
+    err = nvs_set_string(stringlify(WSTA), stringlify(WSTA_SSID), sta_ssid);
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to settin STA ssid to the nvs %s",
+                esp_err_to_name(err));
+    }
+    else {
+        err = init_sta();
+        if (err != ESP_OK) {
+            ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+           return err;
+        }
+    }
+    return ESP_OK;
+}
+
+esp_err_t change_wifi_ap_ssid (char* ap_ssid)
+{
+    esp_err_t err;
+    err = nvs_set_string(stringlify(WAP), stringlify(WAP_SSID), ap_ssid);
+    if (err != ESP_OK) {
+           ESP_LOGE(__func__,
+                "Error: to settin STA ssid to the nvs %s",
+                esp_err_to_name(err));
+    }
+    else {
+       err = init_ap();
+       if (err != ESP_OK) {
+            ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+           return err;
+       }
+    }
+    return ESP_OK;
+}
+
+esp_err_t change_wifi_ap_pass (char* ap_password)
+{
+    esp_err_t err;
+    ESP_LOGE(__func__,"esp_set_string %s", ap_password);
+    err = nvs_set_string(stringlify(WAP), stringlify(WAP_PASS), ap_password);
+    if (err != ESP_OK) {
+         ESP_LOGE(__func__,
+                "Error: to settin AP password to the nvs %s",
+                esp_err_to_name(err));
+    }
+    else {
+       err = init_ap();
+       if (err != ESP_OK) {
+            ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+           return err;
+       }
+    }
+    return ESP_OK;
+}
+
+esp_err_t change_wifi_sta_pass (char* sta_password)
+{
+    esp_err_t err;
+    ESP_LOGE(__func__,"password %s", sta_password);
+    err = nvs_set_string(stringlify(WSTA), stringlify(WSTA_PASS), sta_password);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(__func__,
+                "Error: to setting STA ssid to the nvs %s",
+                esp_err_to_name(err));
+    }
+    else {
+       err = init_sta();
+       if (err != ESP_OK) {
+           ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+           return err;
+       }
+    }
+    return ESP_OK;
+}
+
+esp_err_t select_wifi_channel (uint8_t channel)
+{
+    if (channel == 0 || channel > 7 ) {
+         ESP_LOGE(__func__,
+                "Error: wrong channel, please select a channel in the range of 1 to 7");
+        return ESP_FAIL;
+    }
+
+    esp_err_t err = nvs_set_uint8(stringlify(WAP), stringlify(WAP_CHAN), channel);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(__func__,
+                "Error: to setting AP Channel to the nvs %s",
+                esp_err_to_name(err));
+        return err;
+    }
+
+    err = set_wifi_mode();
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+        return err;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t set_ap_max_connection (uint8_t max_connection)
+{
+    if (max_connection == 0 || max_connection > 4) {
+         ESP_LOGE(__func__,
+                "the connections must be between 1 and 4");
+        return ESP_FAIL;
+    }
+
+    esp_err_t err = nvs_set_uint8(stringlify(WAP), stringlify(WAP_MAXCON), &max_connection);
+    if (err != ESP_OK) {
+
+        ESP_LOGE(__func__,
+                "Error: to setting AP max connections to the nvs %s",
+                esp_err_to_name(err));
+        return err;
+    }
+    err = set_wifi_mode();
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+        return err;
+    }
+
+    return ESP_OK;
+}
+
+
+esp_err_t change_ap_auth (uint8_t auth)
+{
+    if(auth < 10) {
+        ESP_LOGE(__func__, "incorrect auth mode verify the doc and check the auth types");
+    }
+
+    esp_err_t err = nvs_set_uint8(stringlify(WAP), stringlify(WAP_AUTH),auth);
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to setting AP auth to the nvs %s",
+                esp_err_to_name(err));
+    }
+
+    err = set_wifi_mode();
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+        return err;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t change_wifi_mode(int mode)
+{
+    esp_err_t err;
+    if(mode != WIFI_MODE_APSTA &&  mode != WIFI_MODE_AP && mode != WIFI_MODE_STA) {
+        ESP_LOGE(__func__, "the wifi mode received is incorrect");
+        return ESP_FAIL;
+    }
+    err = nvs_set_uint8(stringlify(WIFI),
+                        stringlify(WIFI_MODE),
+                        mode);
+
+    if(err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to set wifi mode %s",
+                esp_err_to_name(err));
+        return ESP_FAIL;
+    }
+    err = set_wifi_mode();
+    if(err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+        return ESP_FAIL;
+    }
+
+   return ESP_OK;
+}
+
+esp_err_t set_wifi_mode ()
+{
+    int mode = 0;
+    esp_err_t err = nvs_get_uint8(stringlify(WIFI), stringlify(WIFI_MODE), &mode);
+
+    if(err != ESP_OK && mode == WIFI_MODE_NULL) {
+
+#if WSTA_ENABLED && WAP_ENABLED
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA));
+    ESP_ERROR_CHECK(init_sta());
+    ESP_ERROR_CHECK(init_ap());
+    return ESP_OK;
+
+#elif WAP_ENABLED
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
+    ESP_ERROR_CHECK(init_ap());
+    return ESP_OK;
+
+#elif WSTA_ENABLED
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(init_sta());
+    return ESP_OK;
+
+#else
+    return ESP_FAIL;
+
+#endif
+    }
+    else {
+        ESP_ERROR_CHECK(esp_wifi_set_mode(mode));
+        if (mode == WIFI_MODE_APSTA) {
+            ESP_ERROR_CHECK(init_sta());
+            ESP_ERROR_CHECK(init_ap());
+        }
+
+        if (mode == WIFI_MODE_STA) {
+            ESP_ERROR_CHECK(init_sta());
+        }
+
+        if (mode == WIFI_MODE_AP) {
+            ESP_ERROR_CHECK(init_ap());
+        }
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t wifi_restore_default()
+{
+   esp_err_t err;
+   err = set_default_credentials();
+   if(err != ESP_OK ) {
+        ESP_LOGE(__func__,
+                "Error: to the set init crendentials %s",
+                esp_err_to_name(err));
+       return err;
+   }
+   err = set_wifi_mode();
+   if(err != ESP_OK ) {
+       ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+       return err;
+   }
+
+   return ESP_OK;
+}
+
 esp_err_t wifi_init(void)
 {
-
-    ESP_LOGI(TAG, "Starting the WiFi module");
+    ESP_LOGI(__func__, "Starting the WiFi module");
 
     if (nvs_init() != ESP_OK)
     {
-        ESP_LOGE(TAG, "Starting the [N]on [V]olarile [S]torage");
+        ESP_LOGE(__func__, "Starting the [N]on [V]olarile [S]torage");
     }
 
     ESP_ERROR_CHECK(esp_netif_init());
@@ -253,29 +687,17 @@ esp_err_t wifi_init(void)
 
     int is_configured = wifi_credentials_are_configured();
 
-    if (!is_configured)
-    {
+    if (!is_configured) {
         set_default_credentials();
     }
 
-#if WSTA_ENABLED && WAP_ENABLED
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA));
-    ESP_ERROR_CHECK(init_sta());
-    ESP_ERROR_CHECK(init_ap());
-    return ESP_OK;
+   esp_err_t err = set_wifi_mode();
+    if(err != ESP_OK) {
+        ESP_LOGE(__func__,
+                "Error: to the init the wifi %s",
+                esp_err_to_name(err));
+        return err;
+    }
 
-#elif WAP_ENABLED
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
-    ESP_ERROR_CHECK(init_ap());
-    return ESP_OK;
-
-#elif WSTA_ENABLED
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-    ESP_ERROR_CHECK(init_sta());
-    return ESP_OK;
-
-#else
-    return ESP_OK;
-
-#endif
+   return ESP_OK;
 }

--- a/wifi-subsys/components/network/src/wifi.h
+++ b/wifi-subsys/components/network/src/wifi.h
@@ -89,6 +89,115 @@ esp_err_t set_default_credentials();
  */
 uint8_t wifi_credentials_are_configured();
 
+/**
+ * @brief change the ssid of the sta and restart the wifi module
+ *
+ * @param sta_ssid [in] new ssid
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t change_wifi_sta_ssid(char* sta_ssid);
+
+/**
+ * @brief change the ssid of the AP and restart the wifi module
+ *         also save new ssid in the nvs
+ *
+ * @param sta_ssid [in] new AP ssid
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t change_wifi_ap_ssid(char* ap_ssid);
+
+/**
+ * @brief change the password of the AP and restart the wifi module
+ *        also save new password in the nvs
+ *
+ * @param sta_ssid [in] new AP password
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t change_wifi_ap_pass(char* pass_ap);
+
+/**
+ * @brief change the password of the STA and restart the wifi module
+ *        also save new password in the nvs
+ *
+ * @param pass_sta [in] new sta password
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t change_wifi_sta_pass(char* pass_sta);
+
+/**
+ * @brief restart the wifi module
+ *
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t wifi_restart();
+
+/**
+ * @brief turn off the WIFI module
+ *
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t wifi_off();
+
+/**
+ * @brief is used when the default parameters still not save in storage,
+ *        this verify that wifi mode is enabled in the default params and
+ *         will return the mode.
+ *
+ * @return int
+ */
+int identify_enabled_interface();
+
+/**
+ * @brief this function set the wifi mode and execute the connection,
+ *         it find the wifi mode in the nvs and it verify if already saved
+ *         the mode in the nvs. If the nvs return error or the wifi_mode is
+ *         equal to WIFI_MODE_NULL will take the defaults params for give
+ *         warranty to the user that wifi init correctly this is very important
+ *         because if something failed  the wifi  will  stop.
+ *
+ */
+esp_err_t set_wifi_mode();
+
+/**
+ * @brief change type of auth in ap wifi
+ *
+ * @param auth [in]
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t change_ap_auth (uint8_t auth);
+
+/**
+ * @brief set new mode in the nvs and start the wifi again.
+ *
+ * @param mode [in]
+ * @return esp_err_t
+ */
+esp_err_t change_wifi_mode(int mode);
+
+/**
+ * @brief restore WiFi parameters to their original state
+ *
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t wifi_restore_default();
+
+/**
+ * @brief select the channel of wifi ap is recommended see the doc
+ * of idf for the channels every channel have a different frequency
+ *
+ * @param channel [in]
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t select_wifi_channel(uint8_t channel);
+
+/**
+ * @brief Set the ap max number of connections
+ *
+ * @param max_connection [in]  max connectios
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t set_ap_max_connection (uint8_t max_connection);
+
 #ifdef __cplusplus
 }
 #endif

--- a/wifi-subsys/components/network/test/test_wifi.c
+++ b/wifi-subsys/components/network/test/test_wifi.c
@@ -16,6 +16,16 @@
 
 #include "unity.h"
 #include "wifi.h"
+#include "storage.h"
+
+TEST_CASE("set default credentials", "[network]")
+{
+    nvs_init();
+    esp_err_t err = set_default_credentials();
+    if(err != ESP_OK){
+        TEST_FAIL();
+    }
+}
 
 TEST_CASE("Wi-Fi initialize", "[network]")
 {
@@ -24,4 +34,65 @@ TEST_CASE("Wi-Fi initialize", "[network]")
     err = wifi_init();
 
     if (err != ESP_OK) TEST_FAIL();
+
+}
+
+TEST_CASE("change ssid ap", "[network]")
+{
+    const char* test_ap = "test-ssid";
+    esp_err_t err = change_wifi_ap_ssid(test_ap);
+    if(err != ESP_OK){
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("change password ap", "[network]")
+{
+    const char* test_ap = "default_password";
+    esp_err_t err = change_wifi_ap_pass(test_ap);
+    if(err != ESP_OK){
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("change ssid sta", "[network]")
+{
+    const char* test_sta = "Chicho";
+    esp_err_t err = change_wifi_sta_ssid(test_sta);
+    if(err != ESP_OK){
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("change password ap", "[network]")
+{
+    const char* test_sta = "Pirulin0312";
+    esp_err_t err = change_wifi_sta_pass(test_sta);
+    if(err != ESP_OK){
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("change channel", "[network]")
+{
+    esp_err_t err = select_wifi_channel(3);
+    if(err != ESP_OK) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("change max_connections", "[network]")
+{
+    esp_err_t err = set_ap_max_connection(2);
+    if(err != ESP_OK) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("change auth ap", "[network]")
+{
+    esp_err_t err = change_ap_auth(WIFI_AUTH_WPA2_PSK);
+    if(err != ESP_OK) {
+        TEST_FAIL();
+    }
 }

--- a/wifi-subsys/components/tools/idf_component.yml
+++ b/wifi-subsys/components/tools/idf_component.yml
@@ -1,0 +1,3 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/cbor: "==0.5.4"

--- a/wifi-subsys/components/uart/CMakeLists.txt
+++ b/wifi-subsys/components/uart/CMakeLists.txt
@@ -1,2 +1,2 @@
 file(GLOB_RECURSE SOURCES src/*.c)
-idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS src ../../main )
+idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS src ../../main REQUIRES network )

--- a/wifi-subsys/components/uart/src/subsys_uart.h
+++ b/wifi-subsys/components/uart/src/subsys_uart.h
@@ -104,6 +104,15 @@ int sendData();
  */
 esp_err_t setting_uart();
 
+/**
+ * @brief  this function parse the AT message is used for get the key and value of at request
+ *
+ * @param at_comant this is the message to parser
+ * @param output    this variable content the key and value
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t parse_at_message(uint8_t* at_comant, at_request_t* output);
+
 #ifdef __cplusplus
 }
 #endif

--- a/wifi-subsys/components/uart/test/uart_test.c
+++ b/wifi-subsys/components/uart/test/uart_test.c
@@ -13,12 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#include <string.h>
 #include "unity.h"
 #include "subsys_uart.h"
 #include "esp_err.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
-TEST_CASE("uart initialize", "[UART]")
+static const char *TAG = "uart_test";
+
+TEST_CASE("uart initialize", "[uart]")
 {
     esp_err_t err;
 
@@ -27,10 +32,112 @@ TEST_CASE("uart initialize", "[UART]")
     if (err != ESP_OK) TEST_FAIL();
 }
 
-TEST_CASE("send uart bytes", "[UART]")
+TEST_CASE("send uart bytes", "[uart]")
 {
     const char* test = "test_data";
     int byteslen = sendData("uart_test", test);
 
     if(byteslen == 0) TEST_FAIL();
+}
+
+TEST_CASE("parse AT message", "[uart]")
+{
+    at_request_t payload;
+    payload.key = malloc(32);
+    payload.value = malloc(32);
+
+    uint8_t test_message[50] = "AT+WSTA_SSID=new_ssid";
+    parse_at_message(test_message, &payload);
+
+    ESP_LOGI(TAG," the key is %s", payload.key);
+    if (strcmp(payload.key, "WSTA_SSID") != 0) {
+        TEST_FAIL();
+    }
+    ESP_LOGI(TAG," the value is is %s", payload.key);
+    if (strcmp(payload.value, "new_ssid") != 0) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("turn on wifi since at handler", "[uart]")
+{
+    char* test_message = "AT+WIFI_ON";
+
+    at_handler((uint8_t*)test_message);
+}
+
+TEST_CASE("restore default params to wifi", "[uart]")
+{
+    char* test_message = "AT+NVS_RST";
+
+    at_handler((uint8_t*)test_message);
+}
+
+TEST_CASE("change wifi ap ssid", "[uart]")
+{
+    char* test_message = "AT+WAP_SSID=test_ssid12";
+
+    at_handler((uint8_t*)test_message);
+}
+
+TEST_CASE("change wifi ap password", "[uart]")
+{
+    char* test_message = "AT+WAP_PASS=test_password";
+
+    at_handler((uint8_t*)test_message);
+}
+
+
+TEST_CASE("change wifi ap ssid", "[uart]")
+{
+    char* test_message = "AT+WSTA_SSID=Chicho";
+
+    at_handler((uint8_t*)test_message);
+}
+
+TEST_CASE("change wifi sta password", "[uart]")
+{
+    char* test_message = "AT+WSTA_PASS=Pirulin0312";
+
+    at_handler((uint8_t*)test_message);
+}
+
+TEST_CASE("restore default params to wifi", "[uart]")
+{
+    char* test_message = "AT+NVS_RST";
+
+    at_handler((uint8_t*)test_message);
+}
+
+TEST_CASE("set ap mode", "[uart]")
+{
+    char* test_message = "AT+WIFI_MODE=2";
+
+    at_handler((uint8_t*)test_message);
+
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
+}
+
+TEST_CASE("set sta mode", "[uart]")
+{
+    char* test_message = "AT+WIFI_MODE=1";
+
+    at_handler((uint8_t*)test_message);
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
+}
+
+TEST_CASE("set sta mode", "[uart]")
+{
+    char* test_message = "AT+WIFI_MODE=3";
+
+    at_handler((uint8_t*)test_message);
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
+}
+
+TEST_CASE("set sta mode", "[uart]")
+{
+    vTaskDelay(3000 / portTICK_PERIOD_MS);
+    char* test_message = "AT+WIFI_MODE";
+
+    at_handler((uint8_t*)test_message);
 }

--- a/wifi-subsys/main/CMakeLists.txt
+++ b/wifi-subsys/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register( SRCS "main.c"
                         INCLUDE_DIRS "."
-                        REQUIRES network storage)
+                        REQUIRES network uart)


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

Was added the modification of the module wifi for be controlled since uart.


<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure

cd test && idf.py build -D "TEST_COMPONENTS=network" flash monitor

```c

Press ENTER to see the list of tests.
I (2803) wifi:ap channel adjust o:6,1 n:4,1
I (2803) wifi:new:<4,0>, old:<6,1>, ap:<4,1>, sta:<4,0>, prof:6
I (3633) wifi:state: init -> auth (b0)
I (3643) wifi:state: auth -> assoc (0)
I (3643) wifi:state: assoc -> run (10)
I (3673) wifi:connected with Chicho, aid = 26, channel 4, BW20, bssid = 60:12:3c:21:03:88
I (3673) wifi:security: WPA2-PSK, phy: bgn, rssi: -64
I (3683) wifi:pm start, type: 1

I (3723) wifi:AP's beacon interval = 102400 us, DTIM period = 1
I (6683) esp_netif_handlers: sta ip: 172.16.0.159, mask: 255.255.255.0, gw: 172.16.0.1
I (6683) Wifi Module: got ip:172.16.0.159

Here's the test menu, pick your combo:
(1)	"set default credentials" [network]
(2)	"Wi-Fi initialize" [network]
(3)	"change ssid ap" [network]
(4)	"change password ap" [network]
(5)	"change ssid sta" [network]
(6)	"change password ap" [network]

```

for test uart functions.

cd test && idf.py build -D "TEST_COMPONENTS=uart" flash monitor

<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

this pr fixes #126 

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->

This PR still is in progress but you already see the code and share with me your opinions.
