### PR TITLE
wifi-subsys: Integration of uint8_t array to Cbor Serialization

### DIFF
--- a/wifi-subsys/components/tools/src/serialization.c
+++ b/wifi-subsys/components/tools/src/serialization.c
@@ -16,31 +16,31 @@
 
 /**
  *
- * @brief       Cbor encoder and decoder functions to manipulate a group of data.
+ * @brief       Cbor encoder and decoder functions to manipulate a group of
+ * data.
  * @author      xkevin190 <kevinvelasco190@gmail.com>
  * @author      eduazocar <eduardo@turpialdev.com>
  */
 
-#include  <stdio.h>
+#include <stdio.h>
+
 #include "cbor.h"
 #include "esp_log.h"
 #include "serialization.h"
 
-static const char* TAG = "SERIALIZATION";
-
-esp_err_t encode(char* key, int64_t value, uint8_t* cbor_coded, size_t *len)
-{
+esp_err_t encode(char *key, int64_t value, uint8_t *cbor_coded, size_t *len) {
     char buffer[100];
     CborEncoder root_encoder;
     CborError err = CborNoError;
     CborEncoder map_encoder;
 
     // Initialize the outermost cbor encoder and create the element_map
-    cbor_encoder_init(&root_encoder, (uint8_t* )buffer, sizeof(buffer), 0);
+    cbor_encoder_init(&root_encoder, (uint8_t *)buffer, sizeof(buffer), 0);
     err = cbor_encoder_create_map(&root_encoder, &map_encoder, 1);
 
     if (err != CborNoError) {
-        ESP_LOGE(TAG, "Error creating map");
+        ESP_LOGE(__func__, "Error creating map\nReason:%s, Error No:%d", cbor_error_string(err),
+                 err);
     }
 
     // Cbor pass to encode the string Key and the int64 value that belong it//
@@ -48,15 +48,46 @@ esp_err_t encode(char* key, int64_t value, uint8_t* cbor_coded, size_t *len)
     cbor_encode_int(&map_encoder, value);
 
     cbor_encoder_close_container(&root_encoder, &map_encoder);
-    *len = cbor_encoder_get_buffer_size(&root_encoder, (uint8_t* )buffer);
+    *len = cbor_encoder_get_buffer_size(&root_encoder, (uint8_t *)buffer);
 
     memcpy(cbor_coded, buffer, *len);
-    ESP_LOG_BUFFER_HEXDUMP(TAG, cbor_coded, *len, ESP_LOG_INFO);
+    ESP_LOG_BUFFER_HEXDUMP(__func__, cbor_coded, *len, ESP_LOG_INFO);
     return ESP_OK;
 }
 
-esp_err_t decode(uint8_t* buf, char* key, int64_t *value, size_t len)
-{
+esp_err_t encode_uint8(char *key, uint8_t *value, uint8_t *cbor_coded, size_t *len) {
+    char buffer[100];
+    CborEncoder root_encoder;
+    CborError err = CborNoError;
+    CborEncoder map_encoder;
+
+    // Initialize the outermost cbor encoder and create the element_map
+    cbor_encoder_init(&root_encoder, (uint8_t *)buffer, sizeof(buffer), 0);
+    err = cbor_encoder_create_map(&root_encoder, &map_encoder, 1);
+
+    if (err != CborNoError) {
+        ESP_LOGE(__func__, "Error creating the map\nReason:%s, Error No:%d", cbor_error_string(err),
+                 err);
+    }
+
+    // Cbor pass to encode the string Key and the int64 value that belong it//
+    cbor_encode_text_stringz(&map_encoder, key);
+    err = cbor_encode_byte_string(&map_encoder, value, sizeof(value) - 1);
+
+    if (err != CborNoError) {
+        ESP_LOGE(__func__, "Wrong passing string bytes\nReason:%s, Error No:%d",
+                 cbor_error_string(err), err);
+        return ESP_FAIL;
+    }
+    cbor_encoder_close_container(&root_encoder, &map_encoder);
+    *len = cbor_encoder_get_buffer_size(&root_encoder, (uint8_t *)buffer);
+
+    memcpy(cbor_coded, buffer, *len);
+    ESP_LOG_BUFFER_HEXDUMP(__func__, cbor_coded, *len, ESP_LOG_INFO);
+    return ESP_OK;
+}
+
+esp_err_t decode(uint8_t *buf, char *key, void *value, size_t len) {
     CborValue it;
     CborValue map_it;
     CborParser root_parser;
@@ -64,28 +95,42 @@ esp_err_t decode(uint8_t* buf, char* key, int64_t *value, size_t len)
     err = cbor_parser_init(buf, len, 0, &root_parser, &it);
 
     if (err != CborNoError) {
-        ESP_LOGE(TAG, "error parser_init encoding: %d ", err);
+        ESP_LOGE(__func__, "error parser_init encoding\nReason:%s, Error No:%d",
+                 cbor_error_string(err), err);
         return ESP_FAIL;
     }
 
     CborType type = cbor_value_get_type(&it);
 
-        if (type == CborMapType) {
-            err = cbor_value_map_find_value(&it, key, &map_it);
+    if (type == CborMapType) {
+        err = cbor_value_map_find_value(&it, key, &map_it);
 
-            if (err != CborNoError) {
-                ESP_LOGE(TAG, "Error Opening map");
-                return ESP_FAIL;
-            }
-
-            else if (!cbor_value_is_valid(&map_it) && !cbor_value_is_integer(&map_it)) {
-                ESP_LOGI(TAG, "no value");
-                return ESP_FAIL;
-            }
-
-            cbor_value_get_int64(&map_it, value);
-
+        if (err != CborNoError) {
+            ESP_LOGE(__func__, "Error opening map\nReason:%s, Error No:%d", cbor_error_string(err),
+                     err);
+            return ESP_FAIL;
         }
+
+        else if (cbor_value_is_valid(&map_it) && cbor_value_is_integer(&map_it)) {
+            cbor_value_get_int64(&map_it, value);
+            return ESP_OK;
+        }
+
+        else if (cbor_value_is_valid(&map_it) && cbor_value_is_byte_string(&map_it)) {
+            uint8_t *val;
+            size_t len_data;
+            cbor_value_dup_byte_string(&map_it, &val, &len_data, &map_it);
+            memcpy(value, val, len_data);
+            free(val);
+            return ESP_OK;
+        }
+
+        else {
+            ESP_LOGE(__func__, "Data and owner not founded\nReason:%s, Error No:%d",
+                     cbor_error_string(err), err);
+            return ESP_FAIL;
+        }
+    }
 
     return ESP_OK;
 }

--- a/wifi-subsys/components/tools/src/serialization.h
+++ b/wifi-subsys/components/tools/src/serialization.h
@@ -30,14 +30,13 @@
 #define SERIALIZATION_H
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 /**
  * @brief method to encode data
  * @param[in] key  Make a name to an element of map.
- * @param[in] value Encode a value that belongs to [key named element]
+ * @param[in] value Encode a value int64 that belongs to [key named element]
  * @param[out] cbor_coded Buffer of coded message in cbor, \
  *                             this contains all elements that will be saved
  * @param[out] len buffer size.
@@ -47,7 +46,28 @@ extern "C"
  *
  */
 
-esp_err_t encode(char* key, int64_t value, uint8_t* cbor_coded, size_t *len);
+esp_err_t encode(char *key, int64_t value, uint8_t *cbor_coded, size_t *len);
+
+/**
+ * @brief method to encode data
+ * @param[in] key  Make a name to an element of map.
+ * @param[in] value Encode a value uint8_t or uint8* that belongs to [key named element]
+ * @param[out] cbor_coded Buffer of coded message in cbor, \
+ *                             this contains all elements that will be saved
+ * @param[out] len buffer size.
+ *
+ * Format of element to be Encoded:
+ * { "key_named" : 1523 };
+ * TO understand could see these groups of bytes as string.
+ *
+ * { "key_name" : "a5f/s*"}
+ *
+ * @note: Take careful to don't send any char or string under uint8_t and uint8_t* types
+ * this function could be take like an array of bytes.
+ *
+ */
+
+esp_err_t encode_uint8(char *key, uint8_t *value, uint8_t *cbor_coded, size_t *len);
 
 /**
  * @brief method to decode data
@@ -57,7 +77,7 @@ esp_err_t encode(char* key, int64_t value, uint8_t* cbor_coded, size_t *len);
  * @param[out] value Value referred of map element [key_named]
  */
 
-esp_err_t decode(uint8_t* buf, char* key, int64_t* value, size_t len);
+esp_err_t decode(uint8_t *buf, char *key, void *value, size_t len);
 
 #ifdef __cplusplus
 }

--- a/wifi-subsys/components/tools/test/test_cbor.c
+++ b/wifi-subsys/components/tools/test/test_cbor.c
@@ -19,103 +19,153 @@
  *
  * @author  eduazocar <eduardo@turpialdev.com>
  */
-#include <stdio.h>
-#include <stdint.h>
-#include "esp_log.h"
-#include "unity.h"
-#include "serialization.h"
 
-static char* key_element[] = {"Key test", "Key_1", "Key_2"};
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "esp_log.h"
+#include "serialization.h"
+#include "unity.h"
+
+static char *key_element[] = {"Key test", "Key_1", "Key_2", "Array_control"};
 size_t len;
-uint8_t cbor_code[20];
+uint8_t cbor_code[50];
 int64_t val_origin;
 int64_t val_received;
+uint8_t array_inp[] = {25, 15, 1};
+uint8_t *array_out;
 
-TEST_CASE("Encode a int value = 34 of an key_element[0]", "cbor")
-{
-    val_origin = 34;
+// *********************** ENCODE SECTION TESTS ++++++++++++++++++++++++++++//
+
+TEST_CASE("Encode a int value = 34 of an key_element[0]", "cbor") {
+
     esp_err_t err = encode(key_element[0], val_origin, cbor_code, &len);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
         TEST_FAIL();
     }
 }
 
-TEST_CASE("Encode a int value = -356 of an key_element[1]", "cbor")
-{
-    val_origin= -356;
+TEST_CASE("Encode a int value = -356 of an key_element[1]", "cbor") {
+
+    val_origin = -356;
     esp_err_t err = encode(key_element[1], val_origin, cbor_code, &len);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
         TEST_FAIL();
     }
 }
 
-TEST_CASE("Encode a int value = 16 of an key_element[2]", "cbor")
-{
+TEST_CASE("Encode a int value = 16 of an key_element[2]", "cbor") {
+
     val_origin = 16;
     esp_err_t err = encode(key_element[2], val_origin, cbor_code, &len);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
         TEST_FAIL();
     }
 }
 
-TEST_CASE("Decode the int value that belongs to key_element[0] ", "cbor")
-{
-    esp_err_t err = decode((uint8_t*)cbor_code, key_element[0], &val_received, len);
+TEST_CASE("Encode an array of some values uint8_t key_element[3]", "cbor") {
+
+    esp_err_t err = encode_uint8(key_element[3], array_inp, cbor_code, &len);
 
     if (err != ESP_OK) {
-        ESP_LOGE("ERROR ", "NO READ");
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
         TEST_FAIL();
     }
-
-    if (val_received != val_origin) {
-        ESP_LOGE("ERROR ", "Wrong Value of the origin");
-        TEST_FAIL();
-    }
-
-    val_received = 0;
-
 }
 
-TEST_CASE("Decode the int value that belongs to key_element[1]", "cbor")
-{
-    ESP_LOGI("R-", "%s", (char *)cbor_code);
-    esp_err_t err = decode((uint8_t*)cbor_code, key_element[1], &val_received, len);
+//*********************** DECODE SECTION TESTS*******************************//
+
+TEST_CASE("Decode the int value that belongs to key_element[0]", "cbor") {
+
+    esp_err_t err = decode((uint8_t *)cbor_code, key_element[0], &val_received, len);
+    ESP_LOGI("The value from origin is ", "%lld --> The value received is %lld",
+             (long long)val_origin, (long long)val_received);
 
     if (err != ESP_OK) {
-        ESP_LOGE("ERROR ", "NO READ");
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
         TEST_FAIL();
     }
 
     if (val_received != val_origin) {
-        ESP_LOGE("ERROR ", "Wrong Value of the origin");
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
         TEST_FAIL();
     }
 
     val_received = 0;
-
 }
 
-TEST_CASE("Decode the int value that belongs to key_element[2]", "cbor")
-{
-    ESP_LOGI("R-", "%s", (char *)cbor_code);
-    esp_err_t err = decode((uint8_t*)cbor_code, key_element[2], &val_received, len);
+TEST_CASE("Decode the int value that belongs to key_element[1]", "cbor") {
 
-    if (err != ESP_OK ) {
-        ESP_LOGE("ERROR ", "NO READ");
+    esp_err_t err = decode((uint8_t *)cbor_code, key_element[1], &val_received, len);
+    ESP_LOGI("The value from origin is ", "%lld --> The value received is %lld",
+             (long long)val_origin, (long long)val_received);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
         TEST_FAIL();
     }
 
     if (val_received != val_origin) {
-        ESP_LOGE("ERROR ", "Wrong Value of the origin");
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
         TEST_FAIL();
     }
 
     val_received = 0;
+}
 
+TEST_CASE("Decode the int value that belongs to key_element[2]", "cbor") {
+
+    esp_err_t err = decode((uint8_t *)cbor_code, key_element[2], &val_received, len);
+    ESP_LOGI("The value from origin is ", "%lld --> The value received is %lld",
+             (long long)val_origin, (long long)val_received);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
+        TEST_FAIL();
+    }
+
+    if (val_received != val_origin) {
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
+        TEST_FAIL();
+    }
+
+    val_received = 0;
+}
+
+TEST_CASE("Decode the uint8_t values that belongs to key_element[3]", "cbor") {
+
+    array_out = malloc(sizeof(len));
+    esp_err_t err = decode((uint8_t *)cbor_code, key_element[3], array_out, len);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
+        TEST_FAIL();
+    }
+
+    if (memcmp(array_inp, array_out, sizeof(array_inp)) != 0) {
+        ESP_LOGE(__func__, "Reason %s, No(%d) in the line:%d by the file %s", esp_err_to_name(err),
+                 err, __LINE__, __FILE__);
+        TEST_FAIL();
+    }
+
+    free(array_out);
+    val_received = 0;
 }


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

This Pull request referred to control to encode and decode arrays of bytes and data type uint8_t. In these changes could see that decode implement a void pointer, that could be help to manipulate other data types and check every one if is that type. So, this can be util to avoid build some functions to encode and decode... The main proposal is to control it with only a function encode and one function decode... Well, there is some close to upgrade for another cases.

<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure

- Upload the program to your develop board esp32-wroom
```sh
idf.py build -D "TEST_COMPONENTS=tools" flash monitor
```
- Then, enter to monitor (Terminal or Serial Communication) and press enter to view all the available tests. 
```sh
Here's the test menu, pick your combo:

(1)	"Encode a int value = 34 of an key_element[0]" cbor
(2)	"Encode a int value = -356 of an key_element[1]" cbor
(3)	"Encode a int value = 16 of an key_element[2]" cbor
(4)	"Encode an array of some values uint8_t key_element[3]" cbor
(5)	"Decode the int value that belongs to key_element[0]" cbor
(6)	"Decode the int value that belongs to key_element[1]" cbor
(7)	"Decode the int value that belongs to key_element[2]" cbor
(8)	"Decode the uint8_t values that belongs to key_element[3]" cbor

Enter test for running.

```

- Probe all the possible combinations to see the results of each test

<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

Fixes #129 

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
