### PR TITLE
wifi-subsys: Adding sntp support to sync time

### DIFF
--- a/wifi-subsys/components/network/src/protocol_sntp.c
+++ b/wifi-subsys/components/network/src/protocol_sntp.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @brief   SNTP (Simple Network Time Protocol)
+ *
+ * @author  eduazocar <eduardo@turpialdev.com>
+ */
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
+#include "esp_attr.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_sleep.h"
+#include "esp_sntp.h"
+#include "esp_system.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+#include "protocol_sntp.h"
+
+esp_err_t init_sntp() {
+    ESP_LOGI(__func__, "Initializing SNTP");
+    sntp_setoperatingmode(SNTP_OPMODE_POLL);
+    sntp_setservername(0, "pool.ntp.org");
+    sntp_init();
+    return ESP_OK;
+}
+
+esp_err_t get_time_sntp(time_t *curr_time, struct tm *curr_timeinfo, char *time_format) {
+    char strftime_buf[64];
+    esp_err_t err;
+    if (curr_timeinfo->tm_year < (2016 - 1900)) {
+        err = init_sntp();
+        if (err != ESP_OK) {
+            ESP_LOGE(__func__, "Failed to init the sntp protocol");
+            return err;
+        }
+        time(curr_time);
+    }
+
+    int retry = 0;
+    const int retry_count = 10;
+    while (sntp_get_sync_status() == SNTP_SYNC_STATUS_RESET && ++retry < retry_count) {
+        ESP_LOGI(__func__, "getting current time: (%d/%d)", retry, retry_count);
+        vTaskDelay(2000 / portTICK_PERIOD_MS);
+        time(curr_time);
+        localtime_r(curr_time, curr_timeinfo);
+        if (retry == retry_count - 1) {
+            ESP_LOGE(__func__, "Failed to sync with ntp server");
+            sntp_stop();
+            return ESP_FAIL;
+        }
+    }
+
+    setenv("TZ", time_format, 1);
+    tzset();
+    localtime_r(curr_time, curr_timeinfo);
+    strftime(strftime_buf, sizeof(strftime_buf), "%c", curr_timeinfo);
+    ESP_LOGI(__func__, "The current date/time of %s is: %s\nTime posix: %lld ms", time_format,
+             strftime_buf, (long long)*curr_time);
+
+    // SNTP has to be off to avoid an system error when is called again //
+    sntp_stop();
+    return ESP_OK;
+}

--- a/wifi-subsys/components/network/src/protocol_sntp.h
+++ b/wifi-subsys/components/network/src/protocol_sntp.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @ingroup     wifi-subsys_components
+ * @{
+ * @brief       sntp (Simple Network Time Protocol)
+ * @author      eduazocar <eduardo@turpialdev.com>
+ *
+ */
+
+#ifndef PROTOCOL_SNTP_H
+#define PROTOCOL_SNTP_H
+
+#include <time.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief This is a main function to initialize the sntp server (This will not be taken, only have
+ * to be applied inside of the function get_time_sntp())
+ */
+esp_err_t init_sntp(void);
+
+/**
+ * @brief this function sync with a server sntp to get a current time and date, this format is
+ * returned in milliseconds (time posix)
+ * @param [inout] curr_time* This is a pointer param to manage the time, this take a time_t var and
+ * manage if was set in the system.
+ * @param [inout] curr_timeinfo* pointer structure to detailed info of the time_t var, in this case
+ * curr_time*
+ * @param [in] time_format This is en input to specific the time format to use UTC
+ */
+esp_err_t get_time_sntp(time_t *curr_time, struct tm *curr_timeinfo, char *time_format);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* PROTOCOL_SNTP_H */
+/** @} */

--- a/wifi-subsys/components/network/test/test_sntp.c
+++ b/wifi-subsys/components/network/test/test_sntp.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @brief   Sntp protocol tests
+ *
+ * @author  eduazocar <eduardo@turpialdev.com>
+ */
+
+#include "esp_log.h"
+#include "protocol_sntp.h"
+#include "storage.h"
+#include "unity.h"
+#include "wifi.h"
+bool wifi_initialized;
+
+TEST_CASE("Get and set time by sntp", "[network][protocols][sntp]") {
+    esp_err_t err;
+    if (!wifi_initialized) {
+        wifi_init();
+        wifi_initialized = true;
+    }
+    time_t now;
+    struct tm now_info;
+    char *format_time = "UTC+4";
+    err = get_time_sntp(&now, &now_info, format_time);
+    if (err != ESP_OK) {
+        ESP_LOGE(__func__, "Reason: %s, No %d, Line: %d, File: %s", esp_err_to_name(err), err,
+                 __LINE__, __FILE__);
+        TEST_FAIL();
+    }
+}


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

Integrations of sntp protocol to get  the current date, time from an zone in specific. 

this implement two functions, init_sntp to connect with an sntp server anf get_time, that works setting the time of the system
<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure

<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

Fixes #134 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
