### PR TITLE
wifi-subsys: icmp implementation

### DIFF
--- a/wifi-subsys/components/network/src/icmp_ping.c
+++ b/wifi-subsys/components/network/src/icmp_ping.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @brief   Wifi module
+ *
+ * @author  xkevin190 <kevinvelasco193@gmail.com>
+ */
+#include <stdio.h>
+#include <string.h>
+#include "ping/ping.h"
+#include "ping/ping_sock.h"
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/netdb.h"
+#include "lwip/dns.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/event_groups.h"
+#include "esp_log.h"
+#include "default_params.h"
+#include "icmp_ping.h"
+
+#define CONNECTED_BIT 1
+#define FAIL_BIT      0
+
+esp_ping_handle_t ping;
+uint8_t is_connected = FAIL_BIT;
+uint8_t is_configured = FAIL_BIT;
+TaskHandle_t manual_ping_task;
+
+void check_on_ping_success(esp_ping_handle_t hdl, void *args)
+{
+    uint8_t ttl;
+    uint16_t seqno;
+    uint32_t elapsed_time, recv_len;
+    ip_addr_t target_addr;
+    esp_ping_get_profile(hdl, ESP_PING_PROF_SEQNO, &seqno, sizeof(seqno));
+    esp_ping_get_profile(hdl, ESP_PING_PROF_TTL, &ttl, sizeof(ttl));
+    esp_ping_get_profile(hdl, ESP_PING_PROF_IPADDR, &target_addr, sizeof(target_addr));
+    esp_ping_get_profile(hdl, ESP_PING_PROF_SIZE, &recv_len, sizeof(recv_len));
+    esp_ping_get_profile(hdl, ESP_PING_PROF_TIMEGAP, &elapsed_time, sizeof(elapsed_time));
+    ESP_LOGI(__func__,"PING %d bytes from %s icmp_seq=%d ttl=%d time=%d ms\n",
+            (int)recv_len, inet_ntoa(target_addr.u_addr.ip4), seqno, ttl, (int)elapsed_time);
+}
+
+void check_on_ping_timeout(esp_ping_handle_t hdl, void *args)
+{
+    uint16_t seqno;
+    ip_addr_t target_addr;
+    esp_ping_get_profile(hdl, ESP_PING_PROF_SEQNO, &seqno, sizeof(seqno));
+    esp_ping_get_profile(hdl, ESP_PING_PROF_IPADDR, &target_addr, sizeof(target_addr));
+    printf("PING From %s icmp_seq=%d timeout\n", inet_ntoa(target_addr.u_addr.ip4), seqno);
+}
+
+void check_on_ping_end(esp_ping_handle_t hdl, void *args)
+{
+    uint32_t transmitted;
+    uint32_t received;
+    uint32_t total_time_ms;
+
+    esp_ping_get_profile(hdl, ESP_PING_PROF_REQUEST, &transmitted, sizeof(transmitted));
+    esp_ping_get_profile(hdl, ESP_PING_PROF_REPLY, &received, sizeof(received));
+    esp_ping_get_profile(hdl, ESP_PING_PROF_DURATION, &total_time_ms, sizeof(total_time_ms));
+    ESP_LOGI(__func__,"PING %d packets transmitted,%d received, time %dms\n",
+                      (int)transmitted,(int)received, (int)total_time_ms);
+
+    if (received > 0) {
+        is_connected = CONNECTED_BIT;
+    }
+    else {
+        is_connected = FAIL_BIT;
+    }
+}
+
+esp_err_t initialize_ping()
+{
+    ip_addr_t target_addr;
+    struct addrinfo hint;
+    struct addrinfo *res = NULL;
+    memset(&hint, 0, sizeof(hint));
+    memset(&target_addr, 0, sizeof(target_addr));
+    int result = getaddrinfo(DEFAULT_SERVER_TO_PING, NULL, &hint, &res);
+    if((result != 0) || (res == NULL)) {
+        is_connected = FAIL_BIT;
+        is_configured = FAIL_BIT;
+        ESP_LOGE(__func__,"DNS lookup failed err=%d res=%p", result, res);
+        return ESP_FAIL;
+    } else {
+        is_configured = CONNECTED_BIT;
+        printf("Initialising ping");
+        struct in_addr addr4  =  ((struct sockaddr_in *) (res->ai_addr))->sin_addr;
+        inet_addr_to_ip4addr(ip_2_ip4(&target_addr), &addr4);
+        freeaddrinfo(res);
+        esp_ping_config_t ping_config = ESP_PING_DEFAULT_CONFIG();
+        ping_config.target_addr = target_addr;   // target IP address
+        ping_config.count = 1;    // ping in infinite mode, esp_ping_stop can stop it
+
+        /* set callback functions */
+        esp_ping_callbacks_t cbs;
+        cbs.on_ping_success = check_on_ping_success;
+        cbs.on_ping_timeout = check_on_ping_timeout;
+        cbs.on_ping_end = check_on_ping_end;
+        cbs.cb_args = NULL;
+
+        esp_err_t err = esp_ping_new_session(&ping_config, &cbs, &ping);
+        if (err != ESP_OK) {
+            ESP_LOGE(__func__,
+                    "Error to the init ping session %s",
+                    esp_err_to_name(err));
+            return err;
+        }
+
+        return ESP_OK;
+    }
+}
+
+void send_ping (void *arg)
+{
+    while (1)
+    {
+        if(!is_configured) {
+            initialize_ping();
+        }
+        esp_ping_start(ping);
+        vTaskDelay(10000 / portTICK_PERIOD_MS);
+    }
+}
+
+uint8_t get_current_status (void)
+{
+    return is_connected;
+}
+
+void ping_task (void *arg)
+{
+    callback_t callback = (callback_t*)arg;
+    esp_ping_start(ping);
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
+    callback(is_connected);
+    vTaskDelete(manual_ping_task);
+}
+
+void manual_ping (callback_t* callback)
+{
+    xTaskCreate(ping_task, "manual_ping", 1024*2, callback, 4, &manual_ping_task);
+}
+
+esp_err_t enable_ping(void)
+{
+    esp_err_t err = initialize_ping();
+    if(err != ESP_OK) {
+        ESP_LOGI(__func__,"Error to the init ping %s", esp_err_to_name(err));
+        return err;
+    }
+    xTaskCreate(send_ping, "ping_task", 1024*2, NULL, configMAX_PRIORITIES, NULL);
+    return ESP_OK;
+}

--- a/wifi-subsys/components/network/src/icmp_ping.h
+++ b/wifi-subsys/components/network/src/icmp_ping.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @{
+ * @brief       icmp module
+ * @copyright   Copyright (c) 2021 Mesh for all
+ * @author      xkevin190 <kevinvelasco193@gmail.com>
+ *
+ */
+#ifndef ICMP_PING_H
+#define ICMP_PING_H
+
+#include "esp_wifi.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+/**
+ * @brief this is a callback will return the current status
+ *
+ */
+typedef void (*callback_t)(int8_t);
+
+/**
+ * @brief init wifi and start a new task
+ *  where send a ping every 60 seconds
+ *
+ * @return esp_err_t
+ */
+esp_err_t enable_ping(void);
+
+/**
+ * @brief this function manually sends the ping
+ *
+ * @return 1 when is connected
+ *         0 when is not connected
+ */
+void manual_ping(callback_t* callback);
+
+/**
+ * @brief get connection status
+ *
+ * @return 1 when is connected
+ *         0 when is not connected
+ */
+uint8_t get_current_status (void);
+
+/**
+ * @brief this function initializes the ping session
+ *
+ * @return esp_err_t
+ */
+esp_err_t initialize_ping(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ICMP_PING_H */
+/** @} */

--- a/wifi-subsys/components/network/test/test_icmp.c
+++ b/wifi-subsys/components/network/test/test_icmp.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "unity.h"
+#include "wifi.h"
+#include "storage.h"
+#include "icmp_ping.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+TEST_CASE("Wi-Fi initialize", "[network]")
+{
+    esp_err_t err;
+    nvs_init();
+    set_default_credentials();
+    err = wifi_init();
+
+    if (err != ESP_OK) TEST_FAIL();
+}
+
+TEST_CASE("setting ping session", "[network]")
+{
+   vTaskDelay(10000 / portTICK_PERIOD_MS);
+
+   esp_err_t err = initialize_ping();
+   if (err != ESP_OK) {
+       TEST_FAIL();
+   }
+}
+
+void callback(uint8_t is_connected)
+{
+    printf("nuevos parametros %d \n", is_connected);
+}
+
+TEST_CASE("send manual ping", "[network]")
+{
+   manual_ping(callback);
+//    if (is_connected == 0) {
+//        TEST_FAIL();
+//    }
+}
+
+TEST_CASE("get current status", "[network]")
+{
+   int is_connected = get_current_status();
+   if (is_connected == 0) {
+       TEST_FAIL();
+   }
+}

--- a/wifi-subsys/components/network/test/test_wifi.c
+++ b/wifi-subsys/components/network/test/test_wifi.c
@@ -17,6 +17,7 @@
 #include "unity.h"
 #include "wifi.h"
 #include "storage.h"
+#include "icmp_ping.h"
 
 TEST_CASE("set default credentials", "[network]")
 {

--- a/wifi-subsys/main/CMakeLists.txt
+++ b/wifi-subsys/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register( SRCS "main.c"
                         INCLUDE_DIRS "."
-                        REQUIRES network uart)
+                        REQUIRES network uart storage)

--- a/wifi-subsys/main/default_params.h
+++ b/wifi-subsys/main/default_params.h
@@ -32,7 +32,7 @@ extern "C"
 /**
  * @brief Simple solution to use custom settings "almost" safely.
  */
-#define USE_DEV_CONFIG 0
+#define USE_DEV_CONFIG 1
 
 /**
  * @brief If it's #1 (true) then **dev-config.h** will be used.
@@ -71,6 +71,7 @@ extern "C"
  */
 #define WIFI
 #define WIFI_MODE
+#define DEFAULT_SERVER_TO_PING  "www.google.com"
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

this pr contains an implementation of ipmc to check the status of the connection, by default the google server was added to check if the esp32 is connected.

<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure
cd test && idf.py build -D "TEST_COMPONENTS=network" flash monitor


```c
Press ENTER to see the list of tests.


Here's the test menu, pick your combo:
(1)	"Wi-Fi initialize" [network]
(2)	"setting ping session" [network]
(3)	"send manual ping" [network]
(4)	"get current status" [network]

```

<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
 This PR fixes #135 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
