### PR TITLE
wifi-subsys: add litle improvements to the wifi module

### DIFF
--- a/wifi-subsys/components/network/src/wifi.h
+++ b/wifi-subsys/components/network/src/wifi.h
@@ -198,6 +198,9 @@ esp_err_t select_wifi_channel(uint8_t channel);
  */
 esp_err_t set_ap_max_connection (uint8_t max_connection);
 
+esp_err_t wifi_start(int8_t *is_connected);
+int8_t wifi_bit_event (void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/wifi-subsys/components/network/test/test_wifi.c
+++ b/wifi-subsys/components/network/test/test_wifi.c
@@ -29,12 +29,17 @@ TEST_CASE("set default credentials", "[network]")
 
 TEST_CASE("Wi-Fi initialize", "[network]")
 {
+    int8_t is_connected = -1;
     esp_err_t err;
-
     err = wifi_init();
 
-    if (err != ESP_OK) TEST_FAIL();
-
+    if (err != ESP_OK) {
+        TEST_FAIL();
+    }
+    err = wifi_start(&is_connected);
+    if (err != ESP_OK) {
+        TEST_FAIL();
+    }
 }
 
 TEST_CASE("change ssid ap", "[network]")
@@ -68,7 +73,7 @@ TEST_CASE("change password ap", "[network]")
 {
     const char* test_sta = "Pirulin0312";
     esp_err_t err = change_wifi_sta_pass(test_sta);
-    if(err != ESP_OK){
+    if(err != ESP_OK) {
         TEST_FAIL();
     }
 }


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

initially this PR was created to return a value when the sta is successfully connected.

The previous implementation was not intended to do this, so the structure had to be modified a bit to make it work correctly.

doing the structure modification I could find several bugs:

1) once connected to a sta and we wanted to connect to another at runtime, the process executed well but the connection was not executed

2) memory overflow when starting wifi_init

3) when stopping the Wi-Fi, the events were not closed when starting the Wi-Fi again, they were initialized again and caused an overflow

4) restart function did not work correctly.

<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure
cd test && idf.py build -D "TEST_COMPONENTS=network" flash monitor

```c
Here's the test menu, pick your combo:
(1)	"set default credentials" [network]
(2)	"Wi-Fi initialize" [network]
(3)	"change ssid ap" [network]
(4)	"change password ap" [network]
(5)	"change ssid sta" [network]
(6)	"change password ap" [network]
(7)	"change channel" [network]
(8)	"change max_connections" [network]
(9)	"change auth ap" [network]

```


<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
this PR fixes #137 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
