### PR TITLE
wifi-subsys: add support for storing uin32 integers in the NVS

### DIFF
--- a/wifi-subsys/components/storage/src/storage.c
+++ b/wifi-subsys/components/storage/src/storage.c
@@ -20,17 +20,15 @@
  * @author  luisan00 <luisan00@hotmail.com>
  */
 
-#include "esp_log.h"
 #include "storage.h"
+#include "esp_log.h"
 
 static const char *TAG = "NVS";
 
-esp_err_t nvs_init(void)
-{
+esp_err_t nvs_init(void) {
     esp_err_t err = nvs_flash_init();
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         ESP_LOGE(TAG, "Fail %s, Initializing the default NVS partition", esp_err_to_name(err));
         return err;
     }
@@ -40,31 +38,29 @@ esp_err_t nvs_init(void)
     return ESP_OK;
 }
 
-esp_err_t nvs_set_uint8(const char *namespace, const char *key, uint8_t value)
-{
+esp_err_t nvs_set_uint8(const char *namespace, const char *key, uint8_t value) {
 
     nvs_handle_t handle;
 
     esp_err_t err = nvs_open(namespace, NVS_READWRITE, &handle);
 
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "Error: %s, trying to open the namespace %s", esp_err_to_name(err), namespace);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error: %s, trying to open the namespace %s", esp_err_to_name(err),
+                 namespace);
         return err;
     }
 
     err = nvs_set_u8(handle, key, value);
 
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "Error: %s, setting the key: %s with value: %d", esp_err_to_name(err), key, value);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error: %s, setting the key: %s with value: %d", esp_err_to_name(err), key,
+                 value);
         return err;
     }
 
     err = nvs_commit(handle);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         ESP_LOGE(TAG, "Error: %s, committing changes", esp_err_to_name(err));
     }
 
@@ -72,31 +68,58 @@ esp_err_t nvs_set_uint8(const char *namespace, const char *key, uint8_t value)
     return ESP_OK;
 }
 
-esp_err_t nvs_set_string(const char *namespace, const char *key, const char *value)
-{
+esp_err_t nvs_set_uint32(const char *namespace, const char *key, uint32_t value) {
 
     nvs_handle_t handle;
 
     esp_err_t err = nvs_open(namespace, NVS_READWRITE, &handle);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error: %s, trying to open the namespace %s", esp_err_to_name(err),
+                 namespace);
+        return err;
+    }
+
+    err = nvs_set_u32(handle, key, value);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error: %s, setting the key: %s with value: %d", esp_err_to_name(err), key,
+                 value);
+        return err;
+    }
+
+    err = nvs_commit(handle);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error: %s, committing changes", esp_err_to_name(err));
+    }
+
+    nvs_close(handle);
+    return ESP_OK;
+}
+
+esp_err_t nvs_set_string(const char *namespace, const char *key, const char *value) {
+
+    nvs_handle_t handle;
+
+    esp_err_t err = nvs_open(namespace, NVS_READWRITE, &handle);
+
+    if (err != ESP_OK) {
         ESP_LOGE(TAG, "Error %s: trying to open the namespace %s", esp_err_to_name(err), namespace);
         return err;
     }
 
     err = nvs_set_str(handle, key, value);
 
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "Error: %s, setting the key: %s with value: %s", esp_err_to_name(err), key, value);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error: %s, setting the key: %s with value: %s", esp_err_to_name(err), key,
+                 value);
         return err;
     }
 
     err = nvs_commit(handle);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         ESP_LOGE(TAG, "Error: %s, committing changes", esp_err_to_name(err));
     }
 
@@ -104,27 +127,23 @@ esp_err_t nvs_set_string(const char *namespace, const char *key, const char *val
     return ESP_OK;
 }
 
-esp_err_t nvs_get_uint8(const char *namespace, const char *key, uint8_t *value)
-{
+esp_err_t nvs_get_uint8(const char *namespace, const char *key, uint8_t *value) {
     nvs_handle_t handle;
 
     esp_err_t err = nvs_open(namespace, NVS_READONLY, &handle);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         ESP_LOGE(TAG, "Error %s: trying to open the namespace %s", esp_err_to_name(err), namespace);
         return err;
     }
 
     err = nvs_get_u8(handle, key, value);
 
-    if (err == ESP_ERR_NVS_NOT_FOUND)
-    {
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
         ESP_LOGD(TAG, "Error %s: not found", esp_err_to_name(err));
         return err;
     }
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         ESP_LOGE(TAG, "Error %s: getting the vañue for key %s", esp_err_to_name(err), key);
     }
 
@@ -133,22 +152,44 @@ esp_err_t nvs_get_uint8(const char *namespace, const char *key, uint8_t *value)
     return ESP_OK;
 }
 
-esp_err_t nvs_get_string(const char *namespace, const char *key, char *buffer, size_t *length)
-{
+esp_err_t nvs_get_uint32(const char *namespace, const char *key, uint32_t *value) {
     nvs_handle_t handle;
 
     esp_err_t err = nvs_open(namespace, NVS_READONLY, &handle);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error %s: trying to open the namespace %s", esp_err_to_name(err), namespace);
+        return err;
+    }
+
+    err = nvs_get_u32(handle, key, value);
+
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGD(TAG, "Error %s: not found", esp_err_to_name(err));
+        return err;
+    }
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error %s: getting the vañue for key %s", esp_err_to_name(err), key);
+    }
+
+    nvs_close(handle);
+
+    return ESP_OK;
+}
+
+esp_err_t nvs_get_string(const char *namespace, const char *key, char *buffer, size_t *length) {
+    nvs_handle_t handle;
+
+    esp_err_t err = nvs_open(namespace, NVS_READONLY, &handle);
+
+    if (err != ESP_OK) {
         ESP_LOGE(TAG, "Error %s: trying to open the namespace %s", esp_err_to_name(err), namespace);
         return err;
     }
 
     err = nvs_get_str(handle, key, NULL, length);
 
-    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND)
-    {
+    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
         ESP_LOGE(TAG, "Error %s: not found", esp_err_to_name(err));
 
         return err;
@@ -156,8 +197,7 @@ esp_err_t nvs_get_string(const char *namespace, const char *key, char *buffer, s
 
     err = nvs_get_str(handle, key, buffer, length);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         ESP_LOGE(TAG, "Error %s: getting the vañue for key %s", esp_err_to_name(err), key);
     }
 

--- a/wifi-subsys/components/storage/src/storage.h
+++ b/wifi-subsys/components/storage/src/storage.h
@@ -22,63 +22,82 @@
 #ifndef STORAGE_H
 #define STORAGE_H
 
-#include <string.h>
-#include <stdbool.h>
 #include "esp_err.h"
 #include "nvs_flash.h"
+#include <stdbool.h>
+#include <string.h>
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-    /**
-     * @brief initialize the default NVS partition
-     *
-     * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
-     */
-    esp_err_t nvs_init(void);
+/**
+ * @brief initialize the default NVS partition
+ *
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t nvs_init(void);
 
-    /**
-     * @brief store a key/value pair in the NVS using the given namespace
-     *
-     * @param [in] namespace
-     * @param [in] key
-     * @param [out] value
-     * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
-     */
-    esp_err_t nvs_set_uint8(const char *namespace, const char *key, uint8_t value);
+/**
+ * @brief store a key/value pair in the NVS using the given namespace
+ *
+ * @param [in] namespace
+ * @param [in] key
+ * @param [out] value uint8_t value to store
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t nvs_set_uint8(const char *namespace, const char *key, uint8_t value);
 
-    /**
-     * @brief Store a c string in the NVS using the given namespace and key
-     *
-     * @param [in] namespace
-     * @param [in] key
-     * @param [in] value
-     * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
-     */
-    esp_err_t nvs_set_string(const char *namespace, const char *key, const char *value);
+/**
+ * @brief store a key/value pair in the NVS using the given namespace
+ *
+ * @param namespace
+ * @param key
+ * @param value uint32_t value to store
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t nvs_set_uint32(const char *namespace, const char *key, uint32_t value);
 
-    /**
-     * @brief Get the value as uint8_t with key [key] from the NVS using the given namespace
-     *
-     * @param [in] namespace
-     * @param [in] key
-     * @param [out] value
-     * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
-     */
-    esp_err_t nvs_get_uint8(const char *namespace, const char *key, uint8_t *value);
+/**
+ * @brief Store a c string in the NVS using the given namespace and key
+ *
+ * @param [in] namespace
+ * @param [in] key
+ * @param [in] value
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t nvs_set_string(const char *namespace, const char *key, const char *value);
 
-    /**
-     * @brief Get the value as c string with key [key] from the NVS using the given namespace
-     *
-     * @param [in] namespace
-     * @param [in] key
-     * @param [out] buffer
-     * @param [out] length
-     * @return esp_err_t
-     */
-    esp_err_t nvs_get_string(const char *namespace, const char *key, char *buffer, size_t *length);
+/**
+ * @brief Get the value as uint8_t with key [key] from the NVS using the given namespace
+ *
+ * @param [in] namespace
+ * @param [in] key
+ * @param [out] value
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t nvs_get_uint8(const char *namespace, const char *key, uint8_t *value);
+
+/**
+ * @brief Get the value as uint32_t with key [key] from the NVS using the given namespace
+ *
+ * @param [in] namespace
+ * @param [in] key
+ * @param [out] value pointer to the uint32_t value
+ * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
+ */
+esp_err_t nvs_get_uint32(const char *namespace, const char *key, uint32_t *value);
+
+/**
+ * @brief Get the value as c string with key [key] from the NVS using the given namespace
+ *
+ * @param [in] namespace
+ * @param [in] key
+ * @param [out] buffer
+ * @param [out] length
+ * @return esp_err_t
+ */
+esp_err_t nvs_get_string(const char *namespace, const char *key, char *buffer, size_t *length);
 
 #ifdef __cplusplus
 }

--- a/wifi-subsys/components/storage/test/test_nvs.c
+++ b/wifi-subsys/components/storage/test/test_nvs.c
@@ -1,14 +1,15 @@
-
-#include "unity.h"
+#include "default_params.h"
 #include "esp_log.h"
 #include "storage.h"
-#include "default_params.h"
-/* default namespace */
-static const char *namespace = "TEST";
+#include "unity.h"
 
 /* uint8_t default params */
 static const char *u8_key = "u8_key";
-static uint8_t u8_value = 111;
+static uint8_t u8_value = 255U;
+
+/* uint32_t default params */
+static const char *u32_key = "u32_key";
+static uint32_t u32_value = 4294967295U;
 
 /* c string  default params */
 static const char *str_key = "str_key";
@@ -17,72 +18,82 @@ static const char *str_value = "str_default_value";
 /* also we need to test some related macro helper, this should be changed */
 #define TEST
 
-TEST_CASE("Literal to String", "nvs")
-{
+TEST_CASE("Literal to String", "nvs") {
     const char *expected = "TEST";
     ESP_LOGI(stringlify(TEST), "stringlify: %s ?= expected: %s", stringlify(TEST), expected);
 
-    if (strcmp(expected, stringlify(TEST)) != 0)
-    {
+    if (strcmp(expected, stringlify(TEST)) != 0) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("Initialize the default nvs partition", "nvs")
-{
+TEST_CASE("Initialize the default nvs partition", "nvs") {
     esp_err_t err = nvs_init();
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("Save a uint8_t in the NVS", "nvs")
-{
+TEST_CASE("Save a uint8_t in the NVS", "nvs") {
     esp_err_t err = nvs_set_uint8(stringlify(TEST), u8_key, u8_value);
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("Get an previusly saved uint8_t from the nvs", "nvs")
-{
-    uint8_t value = 0;
+TEST_CASE("Get a previusly saved uint8_t from the nvs", "nvs") {
+    uint8_t value = 0U;
 
     esp_err_t err = nvs_get_uint8(stringlify(TEST), u8_key, &value);
 
     ESP_LOGI(stringlify(TEST), "%d ?= %d", u8_value, value);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 
-    if (u8_value != value)
-    {
+    if (u8_value != value) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("Save a c string in the nvs", "nvs")
-{
+TEST_CASE("Save a uint32_t in the NVS", "nvs") {
+    esp_err_t err = nvs_set_uint32(stringlify(TEST), u32_key, u32_value);
+    if (err != ESP_OK) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("Get a previusly saved uint32_t from the nvs", "nvs") {
+    uint32_t value = 0U;
+
+    esp_err_t err = nvs_get_uint32(stringlify(TEST), u32_key, &value);
+
+    ESP_LOGI(stringlify(TEST), "%d ?= %d", u32_value, value);
+
+    if (err != ESP_OK) {
+        TEST_FAIL();
+    }
+
+    if (u32_value != value) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("Save a c string in the nvs", "nvs") {
     esp_err_t err = nvs_set_string(stringlify(TEST), str_key, str_value);
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("Get a previously saved c string from the nvs", "nvs")
-{
+TEST_CASE("Get a previously saved c string from the nvs", "nvs") {
     char *buff = NULL;
     size_t buff_size = 0;
 
     esp_err_t err = nvs_get_string(stringlify(TEST), str_key, buff, &buff_size);
 
-    if (err != ESP_OK)
-    {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }


### PR DESCRIPTION
### Contribution description
Add support for storing or reading `uint32_t` type in the Non-Volatile storage 

### Testing procedure
Run the related tests running the following in the test folder:

```sh
idf.py build -D "TEST_COMPONENTS=storage" flash monitor
```
Select option: _Save a uint32_t in the NVS_ (for storing) 
Select option: Get a previously saved uint32_t from the nvs_ (for reading)

### Issues/PRs references
None