### PR TITLE
Revert "wifi-subsys: added event group in icmp"

### DIFF
--- a/wifi-subsys/components/protocols/src/icmp_ping.c
+++ b/wifi-subsys/components/protocols/src/icmp_ping.c
@@ -21,7 +21,8 @@
  */
 #include <stdio.h>
 #include <string.h>
-
+#include "icmp_ping.h"
+#include "default_params.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
@@ -33,10 +34,8 @@
 #include "lwip/sys.h"
 #include "ping/ping.h"
 #include "ping/ping_sock.h"
-
-#include "default_params.h"
-#include "icmp_ping.h"
 #include "storage.h"
+
 
 #define CONNECTED_BIT 1
 #define FAIL_BIT 0
@@ -45,7 +44,6 @@ esp_ping_handle_t ping;
 uint8_t is_connected = FAIL_BIT;
 uint8_t is_configured = FAIL_BIT;
 TaskHandle_t manual_ping_task;
-EventGroupHandle_t s_icmp_event_group;
 
 void check_on_ping_success(esp_ping_handle_t hdl, void *args) {
     uint8_t ttl;
@@ -80,10 +78,8 @@ void check_on_ping_end(esp_ping_handle_t hdl, void *args) {
              (int)received, (int)total_time_ms);
     if (received > 0) {
         is_connected = CONNECTED_BIT;
-        xEventGroupSetBits(s_icmp_event_group, CONNECTED_BIT);
     } else {
         is_connected = FAIL_BIT;
-        xEventGroupSetBits(s_icmp_event_group, FAIL_BIT);
     }
 }
 
@@ -165,7 +161,6 @@ void send_ping(void *arg) {
 uint8_t get_current_status(void) { return is_connected; }
 
 void ping_task(void *arg) {
-    s_icmp_event_group = xEventGroupCreate();
     uint32_t milliseconds = 0;
     callback_t callback = (callback_t *)arg;
     esp_ping_start(ping);
@@ -173,13 +168,11 @@ void ping_task(void *arg) {
                                    &milliseconds); // Milliseconds between each ping procedure
     if (err != ESP_OK) {
         ESP_LOGE(__func__, "error to get ping time the cause is %s", esp_err_to_name(err));
-    } else {
-        xEventGroupWaitBits(s_icmp_event_group, CONNECTED_BIT | FAIL_BIT,
-                                               pdFALSE, pdFALSE, portMAX_DELAY);
 
+    } else {
+        vTaskDelay(milliseconds * 3 / portTICK_PERIOD_MS);
         callback(is_connected);
         vTaskDelete(manual_ping_task);
-        vEventGroupDelete(s_icmp_event_group);
     }
 }
 

--- a/wifi-subsys/components/protocols/test/test_icmp.c
+++ b/wifi-subsys/components/protocols/test/test_icmp.c
@@ -60,8 +60,6 @@ TEST_CASE("Wi-Fi initialize", "[network]") {
     if (err != ESP_OK) {
         TEST_FAIL();
     };
-
-    wifi_start(NULL);
 }
 
 TEST_CASE("setting ping session", "[network]") {


### PR DESCRIPTION
is necessary do a revert because i din't the squash

Reverts Mesh4all/m4a-firmware#150