### PR TITLE
wifi-subsys: fixed little bug in imcp component

### DIFF
--- a/wifi-subsys/components/protocols/test/test_icmp.c
+++ b/wifi-subsys/components/protocols/test/test_icmp.c
@@ -60,6 +60,8 @@ TEST_CASE("Wi-Fi initialize", "[network]") {
     if (err != ESP_OK) {
         TEST_FAIL();
     };
+
+    wifi_start(NULL);
 }
 
 TEST_CASE("setting ping session", "[network]") {

--- a/wifi-subsys/main/main.c
+++ b/wifi-subsys/main/main.c
@@ -106,7 +106,7 @@ esp_err_t set_default_values(void) {
 void save_time(void) {
     time_t saved_time;
     time(&saved_time);
-    if (saved_time != 0){
+    if (saved_time != 0) {
         esp_err_t err = nvs_set_uint32(stringlify(SNTP), stringlify(FIRTS_BOOT), saved_time);
         if (err != ESP_OK) {
             ESP_LOGE(__func__, "Error: setting ping timeout to the nvs %s", esp_err_to_name(err));


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

An event group was added to know the exact moment when the icmp finishes making the ping requests.

This was added because after the ping interval was added dynamically, the function responded before icmp finished making the requests, this caused us not to have the current data.


<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure

Run the related tests running the following in the test folder:

idf.py build -D "TEST_COMPONENTS=protocols" flash monitor


<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.

-->

the PR is related with PR #150 merge by error.