### PR TITLE
wifi-subsys: fixed little bugs in wifi module

### DIFF
--- a/wifi-subsys/components/network/test/test_wifi.c
+++ b/wifi-subsys/components/network/test/test_wifi.c
@@ -17,7 +17,6 @@
 #include "unity.h"
 #include "wifi.h"
 #include "storage.h"
-#include "icmp_ping.h"
 
 TEST_CASE("set default credentials", "[network]")
 {
@@ -98,6 +97,47 @@ TEST_CASE("change max_connections", "[network]")
 TEST_CASE("change auth ap", "[network]")
 {
     esp_err_t err = change_ap_auth(WIFI_AUTH_WPA2_PSK);
+    if(err != ESP_OK) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("change STA mode", "[network]")
+{
+    esp_err_t err = change_wifi_mode(1);
+    if(err != ESP_OK) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("change AP mode", "[network]")
+{
+    esp_err_t err = change_wifi_mode(1);
+    if(err != ESP_OK) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("change APSTA mode", "[network]")
+{
+    esp_err_t err = change_wifi_mode(1);
+    if(err != ESP_OK) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("WIFI OFF", "[network]")
+{
+    esp_err_t err = wifi_off();
+    if(err != ESP_OK) {
+        TEST_FAIL();
+    }
+}
+
+TEST_CASE("WIFI ON", "[network]")
+{
+    esp_err_t err = wifi_init();
+    wifi_start(NULL);
     if(err != ESP_OK) {
         TEST_FAIL();
     }

--- a/wifi-subsys/test/main/main.c
+++ b/wifi-subsys/test/main/main.c
@@ -9,7 +9,7 @@
 void app_main(void)
 {
 
-    unity_run_all_tests();
+    // unity_run_all_tests();
     printf("Starting interactive test menu\n");
     unity_run_menu();
 }


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

When i was doing the uart modification i can saw some mistakes in the correct working of wifi module. After to executed the functions: `wifi_restore_default`,`change_wifi_mode`,`change_wifi_sta_pass`,`change_wifi_ap_ssid`.
the WiFi did not retry the reconnection this was fixed in this PR. also i added more unit test and executed a better test.
<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure

Run the related tests running the following in the test folder:

idf.py build -D "TEST_COMPONENTS=protocols" flash monitor

<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
