### PR TITLE
connection_ESP32_at_commands

### DIFF
--- a/firmware/libs/at_commands_uart/at_uart.c
+++ b/firmware/libs/at_commands_uart/at_uart.c
@@ -69,6 +69,7 @@ at_list_t at_list[] = {
     {"wifi_rst", "", "AT&WIFI_RST", 0, 1},
     {"ath", "", "ATH", 0, 0},
     {"ath0", "", "ATH0", 0, 0},
+    {"at", "", "AT", 0, 1},
     {NULL, NULL, NULL, 0, 0},
 };
 
@@ -84,21 +85,23 @@ void *buff_handler(void *arg) {
     (void)arg;
     msg_t msg;
     msg_t msg_queue[QUEUE_SIZE];
+    char byte;
     msg_init_queue(msg_queue, QUEUE_SIZE);
     while (1) {
         msg_receive(&msg);
-        char character;
         printf("RX: ");
-        do {
-            character = (int)ringbuffer_get_one(&(uart_buffer.rx_buf));
-            uart_buffer.count -= 1;
-            if (character >= ' ' && character <= '~') {
-                printf("%c", character);
-            } else {
-                printf("x%02x", (unsigned char)character);
-            }
-        } while (uart_buffer.count > 0 && character != 0);
-        memset(uart_buffer.rx_mem, 0, UART_BUFSIZE); // clean residual buffer
+        if (ringbuffer_empty(&(uart_buffer.rx_buf)) == 0) {
+            do {
+                byte = (int)ringbuffer_get_one(&(uart_buffer.rx_buf));
+                uart_buffer.count -= 1;
+                if (byte >= ' ' && byte <= '~') {
+                    printf("%c", byte);
+                } else {
+                    printf("x%02x", (unsigned char)byte);
+                }
+            } while (uart_buffer.count > 0 && byte != 0);
+            memset(uart_buffer.rx_mem, 0, UART_BUFSIZE); // clean residual buffer
+        }
     }
     return NULL; // this should never be reached
 }

--- a/firmware/libs/at_commands_uart/include/at_uart.h
+++ b/firmware/libs/at_commands_uart/include/at_uart.h
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 /**
- * @brief       AT COMMAND HANDLER
+ * @ingroup     m4a-firmware
+ * @{
+ * @file
+ * @brief       AT command handler
  *
  * @author      RocioRojas <rociorojas391@gmail.com>
  *
@@ -56,6 +59,7 @@ extern "C" {
     WIFI_RST,      /*!< RESET WIFI */
     ATH,           /*!< START AT */
     ATH0,          /*!< FINISH AT */
+    AT,            /*!< AT CHECK*/
     MAX_AT,        /*!< MAX AT COMMANDS */
 };
 /**

--- a/wifi-subsys/components/uart/src/subsys_uart.c
+++ b/wifi-subsys/components/uart/src/subsys_uart.c
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @brief  Uart handler
+ *
+ * @author xkevin190 <kevinvelasco193@gmail.com>
+ */
 #include <string.h>
 
 #include "subsys_uart.h"
@@ -94,6 +115,9 @@ void rx_receive(void *arg) {
             if (strcmp((char *)data, stringlify(ATH)) == 0) {
                 ESP_LOGI(__func__, "starting at mode");
                 at_mode = 1;
+            } else if ((strcmp((char *)data, stringlify(AT)) == 0) && at_mode == 1) {
+                ESP_LOGI(__func__, "ESP has connection");
+                sendData(__func__, "\r\nok\r\n");
             } else if (strcmp((char *)data, stringlify(ATHO)) == 0) {
                 ESP_LOGI(__func__, "leaving of at mode");
                 at_mode = 0;

--- a/wifi-subsys/components/uart/src/subsys_uart.h
+++ b/wifi-subsys/components/uart/src/subsys_uart.h
@@ -18,7 +18,6 @@
  *
  * @brief       uart module
  *
- * @copyright   Copyright (c) 2021 Mesh for all
  * @author      xkevin190 <kevinvelasco193@gmail.com>
  *
  */


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description
The command  "at at"  allows to know if ESP32 after send "atho" 
<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure
look at firmware/libs/at_commands_uart/at_uart.c and firmware/libs/at_commands_uart/include/at_uart.h
* Try "at at" command to receive an answer from ESP32 in AT mode.

look at wifi-subsys/components/uart/src/subsys_uart.c
* The answer is \r\nok\r\n if connection is ok
<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
none
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
