### PR TITLE
firmware: add basic Kconfig feature

### DIFF
--- a/firmware/Kconfig
+++ b/firmware/Kconfig
@@ -1,0 +1,4 @@
+menu "m4a-firmware configuration"
+rsource "peripherals/Kconfig"
+rsource "sys/Kconfig"
+endmenu

--- a/firmware/peripherals/Kconfig
+++ b/firmware/peripherals/Kconfig
@@ -1,0 +1,4 @@
+menu "Peripherals"
+rsource "ds18_sensor/Kconfig"
+rsource "moisture_sensor/Kconfig"
+endmenu

--- a/firmware/peripherals/ds18_sensor/Kconfig
+++ b/firmware/peripherals/ds18_sensor/Kconfig
@@ -1,0 +1,10 @@
+menu "ds18 for soil"
+# Set if the ds18 for soil is connectd
+config DS18_SOIL_CONNECTED
+    bool "Set if it's connected"
+    default y
+# Set the GPIO where it's connected
+config DS18_SOIL_GPIO
+    int "GPIO where the ds18 is attached"
+    default 0
+endmenu

--- a/firmware/peripherals/moisture_sensor/Kconfig
+++ b/firmware/peripherals/moisture_sensor/Kconfig
@@ -1,0 +1,3 @@
+menu "Moisture sensor setup"
+
+endmenu

--- a/firmware/sys/Kconfig
+++ b/firmware/sys/Kconfig
@@ -1,0 +1,3 @@
+menu "System"
+
+endmenu


### PR DESCRIPTION
### Contribution description
Adds a basic Kconfig function to set some parameters before the build stage
### Testing procedure
Type:
`make menuconfig`
Should appear the **Kconfig** menu

### Issues/PRs references
None