### PR TITLE
Sys: get ipv6 address

### DIFF
--- a/firmware/sys/network/Kconfig
+++ b/firmware/sys/network/Kconfig
@@ -1,6 +1,42 @@
 menu "network"
-    comment "Header using in unique cpuid address"
+
+config SELECT_HEADER_IPV6
+    bool "Edit IPV6 Header"
+    default n
+
+menu "Change default IPV6 header"
+visible if SELECT_HEADER_IPV6
+#comment "Header using in unique cpuid address"
+
     config HEADER_ADDRESS_ID
         string "IPV6 HEADER"
         default "2001:db8:"
+
+endmenu # Change default IPV6 header
+
+menu "Subnet"
+    choice IPV6_MODE
+        prompt "Select IPV6 Subnet mode"
+        config MODE_STATIC
+            bool "STATIC"
+
+        config MODE_RANDOM
+            bool "RANDOM"
+
+        config MODE_MANUAL
+            bool "MANUAL"
+
+    endchoice
+
+    config SUBNET_ADDRESS_ID
+    string "IPV6 SUBNET"
+    default "1111:2222"
+    depends on MODE_MANUAL
+
+    config SEED_XTIMER
+    bool "Using xtimer to seed"
+    default  y
+    depends on MODE_RANDOM
+
+endmenu # Prefix
 endmenu

--- a/firmware/sys/network/Makefile.dep
+++ b/firmware/sys/network/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += random
+USEMODULE += xtimer

--- a/firmware/sys/network/include/uniqueid.h
+++ b/firmware/sys/network/include/uniqueid.h
@@ -17,7 +17,7 @@
  * @ingroup     network
  * @{
  * @file
- * @brief       cpuid address
+ * @brief       IPV6 address
  *
  * @author      RocioRojas <rociorojas391@gmail.com>
  *
@@ -32,12 +32,19 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 /**
- * @brief This function get ipv6 address
+ * @brief  union to get 32 bit random number and convert to a byte array.
+ */
+
+union random_buff {
+    uint8_t u8[4];
+    uint32_t u32;
+};
+/**
+ * @brief This function get ipv6 address (mode: static (default), random, manual)
  * @param [out] addr Address in ipv6 format
  */
-void cpuid_to_ipv6(ipv6_addr_t *addr);
+void subnet_to_ipv6(ipv6_addr_t *addr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description
This function get ipv6 address with the following modes: static (default), random, manual
and with the menuconfig you can change : 
1) The header address (default is 2001:db8)
2) The mode: static, random, manual (by default it's value is set to 1111:2222)

if you choose manual mode you can change the address in menuconfig
<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure
look at firmware/sys/network 
test in main with the following commmand:
```
ipv6_addr_t ipv6 = {
        .u8 = {0},
    };
    subnet_to_ipv6(&ipv6);
     ipv6_addr_print(&ipv6);

```
Note: Make a change in menuconfig to test modes and change header if you need it
<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->Fixes #174 
