### PR TITLE
Wifi-subsys: Instance Mutex-Semaphore in SNTP

### DIFF
--- a/wifi-subsys/components/protocols/src/protocol_sntp.c
+++ b/wifi-subsys/components/protocols/src/protocol_sntp.c
@@ -50,13 +50,13 @@ esp_err_t init_sntp() {
 void get_time_sntp(void *params) {
     callback_time_t callback = (callback_time_t)params;
     time_t now;
-    const int retry_count = SNTP_MAX_COUNT;
     int retry = 0;
     xSemaphoreTake(esp_sntp_mutex, portMAX_DELAY);
-    while (sntp_get_sync_status() != SNTP_SYNC_STATUS_COMPLETED && ++retry <= retry_count) {
-        ESP_LOGI(__func__, "getting current time: (%d/%d)", retry, retry_count);
+    while (sntp_get_sync_status() != SNTP_SYNC_STATUS_COMPLETED && ++retry <= SNTP_MAX_COUNT) {
+        ESP_LOGI(__func__, "getting current time: (%d/%d)", retry, SNTP_MAX_COUNT);
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
         time(&now);
-        if (retry == retry_count) {
+        if (retry == SNTP_MAX_COUNT) {
             ESP_LOGE(__func__, "Failed to sync with ntp server");
         }
     }

--- a/wifi-subsys/components/protocols/src/protocol_sntp.c
+++ b/wifi-subsys/components/protocols/src/protocol_sntp.c
@@ -54,7 +54,7 @@ void get_time_sntp(void *params) {
     xSemaphoreTake(esp_sntp_mutex, portMAX_DELAY);
     while (sntp_get_sync_status() != SNTP_SYNC_STATUS_COMPLETED && ++retry <= SNTP_MAX_COUNT) {
         ESP_LOGI(__func__, "getting current time: (%d/%d)", retry, SNTP_MAX_COUNT);
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
+        vTaskDelay(5000 / portTICK_PERIOD_MS);
         time(&now);
         if (retry == SNTP_MAX_COUNT) {
             ESP_LOGE(__func__, "Failed to sync with ntp server");

--- a/wifi-subsys/components/protocols/src/protocol_sntp.c
+++ b/wifi-subsys/components/protocols/src/protocol_sntp.c
@@ -32,9 +32,12 @@
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
+#include <freertos/semphr.h>
 #include "freertos/task.h"
 #include "protocol_sntp.h"
 #include "storage.h"
+
+SemaphoreHandle_t esp_sntp_mutex = NULL;
 
 esp_err_t init_sntp() {
     ESP_LOGI(__func__, "Initializing SNTP");
@@ -49,14 +52,15 @@ void get_time_sntp(void *params) {
     time_t now;
     const int retry_count = SNTP_MAX_COUNT;
     int retry = 0;
+    xSemaphoreTake(esp_sntp_mutex, portMAX_DELAY);
     while (sntp_get_sync_status() != SNTP_SYNC_STATUS_COMPLETED && ++retry <= retry_count) {
         ESP_LOGI(__func__, "getting current time: (%d/%d)", retry, retry_count);
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
         time(&now);
         if (retry == retry_count) {
             ESP_LOGE(__func__, "Failed to sync with ntp server");
         }
     }
+    xSemaphoreGive(esp_sntp_mutex);
     callback();
     // SNTP has to be off to avoid an system error when is called again //
     sntp_stop();
@@ -64,6 +68,7 @@ void get_time_sntp(void *params) {
 }
 
 esp_err_t sntp_start(callback_time_t callback_sntp) {
+    esp_sntp_mutex = xSemaphoreCreateMutex();
     esp_err_t err = init_sntp();
     xTaskCreate(&get_time_sntp, "Sntp_task", 1024 * 2, callback_sntp, 1, NULL);
     return err;


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

Solution to implement an semaphore or mutex control to sntp task, This will bring a better control and prevision to one or more threads are handling or manipulating the same variable or component... 

<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->


### Testing procedure
Test with idf

```
 idf.py build -D "TEST_COMPONENTS=protocols" flash monitor
```

<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
