### PR TITLE
Wifi updates

### DIFF
--- a/wifi-subsys/components/network/doc.txt
+++ b/wifi-subsys/components/network/doc.txt
@@ -1,0 +1,16 @@
+/**
+@defgroup wifi_component  Wifi routines for the WiFi subsystem
+@ingroup wifi-subsys_components
+@brief Basic routines for handle the wifi-settings (modes[AP, STA, APSTA], wifi_configuration
+[ssid, password, channels, max_connections])
+
+# Overview
+
+Basic routines for handle the wifi system, This will let know the current status of wifi component
+and manipulate its different operating modes, AP, STA and APSTA. These functions provides to the
+Real time handling and easier control of the wifi settings.
+
+@note: When Wifi component is initialized by first time, (first boot), the system will be load all wifi_params
+provides by default_params.h
+
+*/

--- a/wifi-subsys/components/network/src/wifi.c
+++ b/wifi-subsys/components/network/src/wifi.c
@@ -106,14 +106,15 @@ esp_err_t init_sta(void) {
     size_t ssid_len = 0;
     size_t password_len = 0;
 
-    err = nvs_get_string(stringlify(WSTA), stringlify(WSTA_SSID), &sta_config.sta.ssid, &ssid_len);
+    err = nvs_get_string(stringlify(WSTA), stringlify(WSTA_SSID), (char *)&sta_config.sta.ssid,
+                         &ssid_len);
 
     if (err != ESP_OK) {
         ESP_LOGE(__func__, "Error to the get sta password (%s)", esp_err_to_name(err));
         return err;
     }
 
-    err = nvs_get_string(stringlify(WSTA), stringlify(WSTA_PASS), &sta_config.sta.password,
+    err = nvs_get_string(stringlify(WSTA), stringlify(WSTA_PASS), (char *)&sta_config.sta.password,
                          &password_len);
 
     if (err != ESP_OK) {
@@ -195,14 +196,15 @@ esp_err_t init_ap(void) {
 
     memset(&wifi_config, 0, sizeof(wifi_config_t));
 
-    err = nvs_get_string(stringlify(WAP), stringlify(WAP_SSID), &wifi_config.ap.ssid, &ssid_len);
+    err = nvs_get_string(stringlify(WAP), stringlify(WAP_SSID), (char *)&wifi_config.ap.ssid,
+                         &ssid_len);
 
     if (err != ESP_OK) {
         ESP_LOGE(__func__, "error to get WAP SSID the cause is %s", esp_err_to_name(err));
         return err;
     }
 
-    err = nvs_get_string(stringlify(WAP), stringlify(WAP_PASS), &wifi_config.sta.password,
+    err = nvs_get_string(stringlify(WAP), stringlify(WAP_PASS), (char *)&wifi_config.sta.password,
                          &password_len);
 
     if (err != ESP_OK) {
@@ -210,7 +212,8 @@ esp_err_t init_ap(void) {
         return err;
     }
 
-    err = nvs_get_uint8(stringlify(WAP), stringlify(WAP_MAXCON), &wifi_config.ap.max_connection);
+    err = nvs_get_uint8(stringlify(WAP), stringlify(WAP_MAXCON),
+                        (uint8_t *)&wifi_config.ap.max_connection);
     if (err != ESP_OK) {
         ESP_LOGE(__func__, "error to get max_connections the cause is %s", esp_err_to_name(err));
 
@@ -228,7 +231,8 @@ esp_err_t init_ap(void) {
     if (password_len == 0) {
         wifi_config.ap.authmode = WIFI_AUTH_OPEN;
     } else {
-        err = nvs_get_uint8(stringlify(WAP), stringlify(WAP_AUTH), &wifi_config.ap.authmode);
+        err = nvs_get_uint8(stringlify(WAP), stringlify(WAP_AUTH),
+                            (uint8_t *)&wifi_config.ap.authmode);
 
         if (err != ESP_OK) {
             ESP_LOGE(__func__, "error to get ap auth mode the cause is %s", esp_err_to_name(err));
@@ -403,7 +407,7 @@ esp_err_t wifi_restart(void) {
     return ESP_OK;
 }
 
-esp_err_t change_wifi_sta_ssid(char *sta_ssid) {
+esp_err_t change_wifi_sta_ssid(const char *sta_ssid) {
     esp_err_t err;
     s_retry_num = 0;
     err = nvs_set_string(stringlify(WSTA), stringlify(WSTA_SSID), sta_ssid);
@@ -418,7 +422,7 @@ esp_err_t change_wifi_sta_ssid(char *sta_ssid) {
     return ESP_OK;
 }
 
-esp_err_t change_wifi_ap_ssid(char *ap_ssid) {
+esp_err_t change_wifi_ap_ssid(const char *ap_ssid) {
     esp_err_t err;
     err = nvs_set_string(stringlify(WAP), stringlify(WAP_SSID), ap_ssid);
     if (err != ESP_OK) {
@@ -432,7 +436,7 @@ esp_err_t change_wifi_ap_ssid(char *ap_ssid) {
     return ESP_OK;
 }
 
-esp_err_t change_wifi_ap_pass(char *ap_password) {
+esp_err_t change_wifi_ap_pass(const char *ap_password) {
     esp_err_t err;
     ESP_LOGE(__func__, "esp_set_string %s", ap_password);
     err = nvs_set_string(stringlify(WAP), stringlify(WAP_PASS), ap_password);
@@ -447,7 +451,7 @@ esp_err_t change_wifi_ap_pass(char *ap_password) {
     return ESP_OK;
 }
 
-esp_err_t change_wifi_sta_pass(char *sta_password) {
+esp_err_t change_wifi_sta_pass(const char *sta_password) {
     esp_err_t err;
     ESP_LOGE(__func__, "password %s", sta_password);
     err = nvs_set_string(stringlify(WSTA), stringlify(WSTA_PASS), sta_password);
@@ -489,7 +493,7 @@ esp_err_t set_ap_max_connection(uint8_t max_connection) {
         return ESP_FAIL;
     }
 
-    esp_err_t err = nvs_set_uint8(stringlify(WAP), stringlify(WAP_MAXCON), &max_connection);
+    esp_err_t err = nvs_set_uint8(stringlify(WAP), stringlify(WAP_MAXCON), max_connection);
     if (err != ESP_OK) {
 
         ESP_LOGE(__func__, "Error: to setting AP max connections to the nvs %s",
@@ -549,7 +553,7 @@ esp_err_t change_wifi_mode(int mode) {
 
 esp_err_t set_wifi_mode() {
     s_wifi_event_group = xEventGroupCreate();
-    int mode = 0;
+    uint8_t mode = 0;
     esp_err_t err = nvs_get_uint8(stringlify(WIFI), stringlify(WIFI_MODE), &mode);
 
     esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL,

--- a/wifi-subsys/components/network/src/wifi.h
+++ b/wifi-subsys/components/network/src/wifi.h
@@ -17,7 +17,7 @@
 /**
  *
  * @brief       Wifi module
- * @ingroup     wifi-subsys_components
+ * @ingroup     wifi_component
  * @{
  * @copyright   Copyright (c) 2021 Mesh for all
  * @author      xkevin190 <kevinvelasco193@gmail.com>
@@ -94,25 +94,25 @@ uint8_t wifi_credentials_are_configured();
  * @param sta_ssid [in] new ssid
  * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
  */
-esp_err_t change_wifi_sta_ssid(char *sta_ssid);
+esp_err_t change_wifi_sta_ssid(const char *sta_ssid);
 
 /**
  * @brief change the ssid of the AP and restart the wifi module
  *         also save new ssid in the nvs
  *
- * @param sta_ssid [in] new AP ssid
+ * @param ap_ssid [in] new AP ssid
  * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
  */
-esp_err_t change_wifi_ap_ssid(char *ap_ssid);
+esp_err_t change_wifi_ap_ssid(const char *ap_ssid);
 
 /**
  * @brief change the password of the AP and restart the wifi module
  *        also save new password in the nvs
  *
- * @param sta_ssid [in] new AP password
+ * @param pass_ap [in] new AP password
  * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
  */
-esp_err_t change_wifi_ap_pass(char *pass_ap);
+esp_err_t change_wifi_ap_pass(const char *pass_ap);
 
 /**
  * @brief change the password of the STA and restart the wifi module
@@ -121,7 +121,7 @@ esp_err_t change_wifi_ap_pass(char *pass_ap);
  * @param pass_sta [in] new sta password
  * @return esp_err_t ESP_OK: succeed, ESP_(others): fail
  */
-esp_err_t change_wifi_sta_pass(char *pass_sta);
+esp_err_t change_wifi_sta_pass(const char *pass_sta);
 
 /**
  * @brief restart the wifi module

--- a/wifi-subsys/components/network/test/test_wifi.c
+++ b/wifi-subsys/components/network/test/test_wifi.c
@@ -18,17 +18,15 @@
 #include "wifi.h"
 #include "storage.h"
 
-TEST_CASE("set default credentials", "[network]")
-{
+TEST_CASE("set default credentials", "[network]") {
     nvs_init();
     esp_err_t err = set_default_credentials();
-    if(err != ESP_OK){
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("Wi-Fi initialize", "[network]")
-{
+TEST_CASE("Wi-Fi initialize", "[network]") {
     int8_t is_connected = -1;
     esp_err_t err;
     err = wifi_init();
@@ -42,103 +40,91 @@ TEST_CASE("Wi-Fi initialize", "[network]")
     }
 }
 
-TEST_CASE("change ssid ap", "[network]")
-{
-    const char* test_ap = "test-ssid";
+TEST_CASE("change ssid ap", "[network]") {
+    const char *test_ap = "test-ssid";
     esp_err_t err = change_wifi_ap_ssid(test_ap);
-    if(err != ESP_OK){
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("change password ap", "[network]")
-{
-    const char* test_ap = "default_password";
+TEST_CASE("change password ap", "[network]") {
+    const char *test_ap = "default_password";
     esp_err_t err = change_wifi_ap_pass(test_ap);
-    if(err != ESP_OK){
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("change ssid sta", "[network]")
-{
-    const char* test_sta = "Chicho";
+TEST_CASE("change ssid sta", "[network]") {
+    const char *test_sta = "Chicho";
     esp_err_t err = change_wifi_sta_ssid(test_sta);
-    if(err != ESP_OK){
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("change password ap", "[network]")
-{
-    const char* test_sta = "Pirulin0312";
+TEST_CASE("change password ap", "[network]") {
+    const char *test_sta = "Pirulin0312";
     esp_err_t err = change_wifi_sta_pass(test_sta);
-    if(err != ESP_OK) {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("change channel", "[network]")
-{
+TEST_CASE("change channel", "[network]") {
     esp_err_t err = select_wifi_channel(3);
-    if(err != ESP_OK) {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("change max_connections", "[network]")
-{
+TEST_CASE("change max_connections", "[network]") {
     esp_err_t err = set_ap_max_connection(2);
-    if(err != ESP_OK) {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("change auth ap", "[network]")
-{
+TEST_CASE("change auth ap", "[network]") {
     esp_err_t err = change_ap_auth(WIFI_AUTH_WPA2_PSK);
-    if(err != ESP_OK) {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("change STA mode", "[network]")
-{
+TEST_CASE("change STA mode", "[network]") {
     esp_err_t err = change_wifi_mode(1);
-    if(err != ESP_OK) {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("change AP mode", "[network]")
-{
-    esp_err_t err = change_wifi_mode(1);
-    if(err != ESP_OK) {
+TEST_CASE("change AP mode", "[network]") {
+    esp_err_t err = change_wifi_mode(2);
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("change APSTA mode", "[network]")
-{
-    esp_err_t err = change_wifi_mode(1);
-    if(err != ESP_OK) {
+TEST_CASE("change APSTA mode", "[network]") {
+    esp_err_t err = change_wifi_mode(3);
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("WIFI OFF", "[network]")
-{
+TEST_CASE("WIFI OFF", "[network]") {
     esp_err_t err = wifi_off();
-    if(err != ESP_OK) {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }
 
-TEST_CASE("WIFI ON", "[network]")
-{
+TEST_CASE("WIFI ON", "[network]") {
     esp_err_t err = wifi_init();
     wifi_start(NULL);
-    if(err != ESP_OK) {
+    if (err != ESP_OK) {
         TEST_FAIL();
     }
 }


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions
-->

### Contribution description

This Pr brings a little changes and updates in wifi.c, here is resolved all build warnings manifested with some no-casted values called for some nvs functions... Changes the use of int8_t to maintain the standard datatype uint8_t, with this also control the Bit state of event groups, so this will allow that the function wifi_bit_event() could be called from another protocols and networks elements to check if the wifi, is connected or not. Another features to brings this PR, its a better structured documentation of wifi-routines inside the wifi-subsystem element.

<!--
Description (as detailed as possible) of your contribution.
- describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes
-->

### Testing procedure
```sh
idf.py -D "TEST_COMPONENTS=network" flash monitor
```

<!--
How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fixes #196 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
