### PR TITLE
ci: update labeler runner

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,7 +7,7 @@
   - "**/*.mk"
 
 "Area: CI":
-  - ".github/**/*.yml"
+  - ".github/**/*"
 
 "Area: firmware":
   - "firmware/**/*"
@@ -16,6 +16,7 @@
   - "doc/**/*"
   - "**/*.md"
   - "**/*.txt"
+  - ".github/**/*.md"
 
 "Area: drivers":
   - "drivers/**/*"


### PR DESCRIPTION
### Contribution description
The **labeler check** should put `Area: doc` and `Area: ci` for  new PRs with changes in `md` files, in  the `.github` folder

### Testing procedure
- *labeler* shoild works as expected opening a new PR with changes in some of the `*.md` files in the `.github` folder

- or see the **labeler.yml** in `.github/`

### Issues/PRs references
None
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->