### PR TITLE
CI : Fixing Codespell undetected misspelling words during static-test

### DIFF
--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -10,7 +10,8 @@ CODESPELL_OPT=" -c"
 CODESPELL_OPT+=" -q 2"
 CODESPELL_OPT+=" --check-hidden"
 CODESPELL_OPT+=" --ignore-words ${TOOLS}/codespell/ignored_words.txt"
-CODESPELL_OPT+=" --skip=RIOT,dist,./wifi-subsys/build,.git,css,html,js,m4a.doxyfile"
+CODESPELL_OPT+=" --skip=RIOT,dist,build,bin,.git,css,html,js,m4a.doxyfile,makefiles"
+CODESPELL_OPT+=" -D ${TOOLS}/codespell/dictionary_m4a.txt -D -"
 ERRORS=$(${CODESPELL_CMD} ${CODESPELL_OPT})
 
 if [ -n "${ERRORS}" ]

--- a/dist/tools/codespell/dictionary_m4a.txt
+++ b/dist/tools/codespell/dictionary_m4a.txt
@@ -1,0 +1,2 @@
+mdoule->module
+scren->screen


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description

This PR implements a solution to codespell not found misspelling errors, resolves some wrong pointed paths and add an dictionary.txt to run static-test locally. 

<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure

There are two ways to test the static test
- First (Running by static test)
```sh
make static-test
```
- Second running in dist/tools/codespell
```c
cd dist/tools/codespell
./check.sh
```
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fix #211 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
