### PR TITLE
Wifi-subsys: Delete build warnings from icmp and recover https erased element

### DIFF
--- a/wifi-subsys/components/protocols/src/httpsclient.h
+++ b/wifi-subsys/components/protocols/src/httpsclient.h
@@ -38,7 +38,6 @@ extern "C" {
 #define MAX_HTTP_OUTPUT_BUFFER 1024 /*!< maximum size to send */
 
 #define HTTPS_CONTENT_JSON "application/json"
-#define HTTPS_CONTENT_CBOR "application/cbor"
 
 /**
  * @brief Struct to save status, content_len, output.
@@ -64,6 +63,7 @@ typedef struct {
     int method;                   /*!< Make a method get/post */
     char url[200];                /*!< Url used */
     char body[100];               /*!< body used with method post */
+    char *content_type; /*Content type field of http request*/
     response_callback_t callback; /*!< callback executed when the serve response */
 } http_request_t;
 /** @}  */

--- a/wifi-subsys/components/protocols/src/icmp_ping.h
+++ b/wifi-subsys/components/protocols/src/icmp_ping.h
@@ -34,7 +34,7 @@ extern "C" {
  * @brief this is a callback will return the current status
  *
  */
-typedef void (*callback_t)(int8_t);
+typedef void (*callback_t)(uint8_t);
 
 /**
  * @brief init wifi and start a new task
@@ -50,7 +50,7 @@ esp_err_t enable_ping(void);
  * @return 1 when is connected
  *         0 when is not connected
  */
-void manual_ping(callback_t *callback);
+void manual_ping(callback_t callback);
 
 /**
  * @brief  get connection status

--- a/wifi-subsys/components/protocols/test/test_icmp.c
+++ b/wifi-subsys/components/protocols/test/test_icmp.c
@@ -32,7 +32,7 @@ esp_err_t set_default_ping_settings(void) {
     if (err != ESP_OK) {
         ESP_LOGE(__func__, "Error: setting ping interval to the nvs %s", esp_err_to_name(err));
     }
-    err = nvs_set_uint8(stringlify(PING), stringlify(PING_RET), PING_RET);
+    err = nvs_set_uint32(stringlify(PING), stringlify(PING_RET), PING_RET);
     if (err != ESP_OK) {
         ESP_LOGE(__func__, "Error: setting ping retries to the nvs %s", esp_err_to_name(err));
     }
@@ -66,7 +66,6 @@ TEST_CASE("Wi-Fi initialize", "[network]") {
 
 TEST_CASE("setting ping session", "[network]") {
     set_default_ping_settings();
-    vTaskDelay(10000 / portTICK_PERIOD_MS);
     initialize_ping();
 }
 


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description

Implementation of some casting to fix some warning when it's build the protocols software, it's about all sectors of icmp, where was passing by nvs a value `uint8_t` to `uint32_t` pointer-variable, another warning was about `manual_ping` callback param, This function has the proposite is pass a function as parameter, so the `callback_t`  solve this pointer, it's not necessary make a pointer param to get a function... These changes also resolves the previously conflict where a little part of https was erased, 
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
move to wifi-subsys/test directory and then run:
```sh
idf.py build -D "TEST_COMPONENTS=protocols" flash monitor
```
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

Fixes #195 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
