### PR TITLE
Firmware: makes Kconfig

### DIFF
--- a/firmware/Kconfig
+++ b/firmware/Kconfig
@@ -1,4 +1,28 @@
 menu "m4a-firmware configuration"
 rsource "peripherals/Kconfig"
 rsource "sys/Kconfig"
+rsource "network/Kconfig"
+
+menu "PHY settings"
+#comment "PHY settings"
+    config TX_POWER
+    string "TX Power"
+    default "0"
+
+    config RADIO_CHANNEL
+    string "Radio Channel default"
+    default "1"
+
+endmenu #Phy
+
+menu "Interface"
+#comment "Interface wifi and Radio"
+config WIFI_SUBSYSTEM
+    bool "Wifi-Subsytem Interface"
+    default y
+
+config IEEE_802154
+    bool "Radio Interface"
+    default n
+endmenu #interface
 endmenu

--- a/firmware/network/Kconfig
+++ b/firmware/network/Kconfig
@@ -1,0 +1,4 @@
+menu "Network"
+rsource "udp_server/Kconfig"
+rsource "udp_client/Kconfig"
+endmenu

--- a/firmware/network/udp_client/Kconfig
+++ b/firmware/network/udp_client/Kconfig
@@ -1,0 +1,3 @@
+menu "UDP Client"
+# TO DO
+endmenu

--- a/firmware/network/udp_server/Kconfig
+++ b/firmware/network/udp_server/Kconfig
@@ -1,0 +1,3 @@
+menu "UDP Server"
+# TO DO
+endmenu

--- a/firmware/sys/Kconfig
+++ b/firmware/sys/Kconfig
@@ -1,3 +1,6 @@
 menu "System"
 rsource "uniqueid/Kconfig"
+rsource "serialization/Kconfig"
+rsource "storage/Kconfig"
+rsource "at_client/Kconfig"
 endmenu

--- a/firmware/sys/at_client/Kconfig
+++ b/firmware/sys/at_client/Kconfig
@@ -1,0 +1,3 @@
+menu "AT Client"
+# TO DO
+endmenu

--- a/firmware/sys/serialization/Kconfig
+++ b/firmware/sys/serialization/Kconfig
@@ -1,0 +1,3 @@
+menu "Serialization"
+# TO DO
+endmenu

--- a/firmware/sys/storage/Kconfig
+++ b/firmware/sys/storage/Kconfig
@@ -1,0 +1,3 @@
+menu "Storage"
+# TO DO
+endmenu

--- a/firmware/sys/uniqueid/Kconfig
+++ b/firmware/sys/uniqueid/Kconfig
@@ -1,4 +1,4 @@
-menu "uniqueid"
+menu "Uniqueid"
 
 config SELECT_HEADER_IPV6
     bool "Edit IPV6 Header"


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
Makes Kconfig files for Firmware module
     - Makes the PHY setting to tx_power and radio channel
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
Look at  firmware
use command 
``` make menuconfig```
In the following modules the Kconfig files need to be completed:
   - Network folder:
          * udp_server
          * udp_client
   - Sys folder:
          * at_client
          * serialization
          *  storage
 
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fixes #222 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
