### PR TITLE
boards: update driver at86rf213 to at86rf233

### DIFF
--- a/boards/m4a-24g/Makefile.dep
+++ b/boards/m4a-24g/Makefile.dep
@@ -1,5 +1,5 @@
 ifneq (,$(filter netdev_default,$(USEMODULE)))
-  USEMODULE += at86rf215
+  USEMODULE += at86rf233
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
The driver in m4a-24g it's not reading by auto_init_gnrc_netif and netdec_default, because the referred driver it's wrong, the at86rf213 doesn't exist in samr21. see also in samr21 datasheet about more info.
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
Use the RIOT submodule to testing with gnrc_networkin example:
```sh
cd RIOT/examples/gnrc_networking
```
```
make flash term
```
In the m4a-firmware shell execute the command line:
```sh
ifconfig
```
Then of previous steps, you should see the integrated radio as a network interface

<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
