### PR TITLE
firmware: Radio modification to manage various same type ifaces

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -37,7 +37,6 @@ static shell_command_t shell_extended_commands[] = {
 int main(void)
 {
     LOG_INFO("~~ Welcome to Mesh4all ~~\n");
-
     /* Start shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
 

--- a/firmware/network/radio/Kconfig
+++ b/firmware/network/radio/Kconfig
@@ -1,11 +1,42 @@
 menu "PHY settings"
+depends on IEEE_802154
 #comment "PHY settings"
+    config MODE_SUB_24GHZ
+    bool "Mode Sub 2.4GHz"
+    default n
+    depends on USEMODULE_AT86RF215 || USEMODULE_CC2538_RF
+
+    #AT86RF215
     config TX_POWER
     int "Default TX Power"
     default 0
+    range -28 3
+    depends on USEMODULE_AT86RF215
+
+    #AT86RF233
+    config TX_POWER
+    int "Default TX Power"
+    default 0
+    range -17  4
+    depends on USEMODULE_AT86RF233
+
+    #CC2538
+    config TX_POWER
+    int "Default TX Power"
+    default 0
+    range -24 7
+    depends on USEMODULE_CC2538_RF
 
     config RADIO_CHANNEL
     int "Default Radio Channel"
     default 11
+    range 11 26
+    depends on !MODE_SUB_24GHZ
+
+    config SUB_RADIO_CHANNEL
+    int "Default Radio Channel Sub 2.4GHz"
+    default 0
+    range 0 10
+    depends on MODE_SUB_24GHZ
 
 endmenu #Phy

--- a/firmware/network/radio/Makefile.dep
+++ b/firmware/network/radio/Makefile.dep
@@ -3,20 +3,3 @@ USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_netif_ieee802154
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += uniqueid
-
-#Drivers specifications atmel series
-
-ifneq (,$(filter at86rf212b,$(USEMODULE)))
-    CFLAGS += -DMAX_TX_POWER=11
-    CFLAGS += -DMIN_TX_POWER=-17
-endif
-
-ifneq (,$(filter at86rf231 at86rf232,$(USEMODULE)))
-    CFLAGS += -DMAX_TX_POWER=3
-    CFLAGS += -DMIN_TX_POWER=-17
-endif
-
-ifneq (,$(filter at86rf233,$(USEMODULE)))
-    CFLAGS += -DMAX_TX_POWER=4
-    CFLAGS += -DMIN_TX_POWER=-17
-endif

--- a/firmware/network/radio/include/radio.h
+++ b/firmware/network/radio/include/radio.h
@@ -30,14 +30,7 @@
 
 #include "net/gnrc.h"
 #include "net/netdev.h"
-
-#ifndef MAX_TX_POWER
-#define MAX_TX_POWER (20)
-#endif
-
-#ifndef MIN_TX_POWER
-#define MIN_TX_POWER (-17)
-#endif
+#include "radio_params.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -110,8 +103,14 @@ int8_t set_sleep_interface(void);
  */
 int8_t set_awake_interface(void);
 
+/**
+ * @brief function used to determinate if there is a radio multiband interface
+ * @return bool (True is Multiband, False is Single-Band)
+ */
+bool identify_multiple_radio_interface(void);
+
 #ifdef __cplusplus
 }
 #endif
 #endif /* RADIO_H */
-/**@}*/
+       /**@}*/

--- a/firmware/network/radio/include/radio_params.h
+++ b/firmware/network/radio/include/radio_params.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @{
+ * @ingroup     network
+ * @file        radio_params.h
+ * @brief       this module content all params to set the radio
+ * @author      xkevin190 <kevinvelasco193@gmail.com.com>
+ * @author      eduazocar <eduazocarv@gmail.com>
+ * @author      RocioRojas <rociorojas391@gmail.com>
+ *
+ */
+
+#ifndef RADIO_PARAMS_H
+#define RADIO_PARAMS_H
+
+#include "net/gnrc.h"
+#include "net/netdev.h"
+#include "net/gnrc/netif.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Drivers Params List
+ *
+ * | Driver    |TX_POWER_MIN (dBm) | TX_POWER_MAX (dBm)|
+ * |:---------:|:-----------------:|:-----------------:|
+ * | at86rf215 |       -28         |         +3        |
+ * | at86rf233 |       -17         |         +4        |
+ * | cc2538    |       -24         |         +7        |
+ */
+
+#ifdef MODULE_AT86RF233
+#define TX_POWER_MAX (4)
+#define TX_POWER_MIN (-17)
+#endif
+
+#ifdef MODULE_AT86RF215
+#define TX_POWER_MAX (3)
+#define TX_POWER_MIN (-28)
+#endif
+
+#ifdef MODULE_CC2538
+#define TX_POWER_MAX (7)
+#define TX_POWER_MIN (-24)
+#endif
+
+#ifndef CONFIG_TX_POWER
+#define CONFIG_TX_POWER (0)
+#endif
+
+#ifndef CONFIG_RADIO_CHANNEL
+#define CONFIG_RADIO_CHANNEL (11)
+#endif
+
+/** @name Driver_Default_Params
+ *  @note  Every param is empty when the device is unknown
+ * @{
+ */
+
+#ifndef TX_POWER_MAX
+#define TX_POWER_MAX (0) /*!< Max Tx_power value from the driver */
+#endif
+
+#ifndef TX_POWER_MIN
+#define TX_POWER_MIN (0) /*!< Min Tx_power value from the driver */
+#endif
+
+/**@}*/
+
+#ifndef CONFIG_TX_POWER
+#define CONFIG_TX_POWER (0)
+#endif
+
+#ifndef CONFIG_RADIO_CHANNEL
+#define CONFIG_RADIO_CHANNEL (11)
+#endif
+
+#ifndef CONFIG_SUB_RADIO_CHANNEL
+#define CONFIG_SUB_RADIO_CHANNEL (0)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RADIO_PARAMS_H */
+/**@}*/


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
Radio module funtions are dependent of get_ieee802154_iface(), these affect to multi-operatibility with various interfaces inside an net device. To resolve this each function could refers to an index of an iface.

current operatibility it's represented:
![radio_module_v1 0 drawio](https://user-images.githubusercontent.com/93989980/164134452-9147ad65-5a9d-4d6c-8bad-afc5ace21a63.png)
if it's used get_ieee802154_iface to return a group of ifaces, every iface will be affected by the selected operation. e.g: an device has a driver at86rf233 and a driver at86rf215, if `get_ieee802154_iface()` returns both id ifaces, these same interfaces will be modiffied.

The propose solution it's bring to each option a parameter to refers index of an interface:
![radio_module_v1 0 drawio (1)](https://user-images.githubusercontent.com/93989980/164135038-1bf3ec9a-8c8a-4015-aef3-cac182590d6c.png)

An index interface offers a flexibility to setup an interface one by one.

This PR add some radio_params to get TX_POWER of an determinate module... This last feature has to offer a type of structure to manage the specified limit to the specified driver
 

<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.

-->


### Testing procedure

<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
