### PR TITLE
Makefile: New Integration to manage bootloader Commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
+
 # With HomeBrew into MacOS systems make is installed as "gmake"
+
 ifeq ($(shell uname -s), Darwin)
 	MAKE_CMD := gmake
 else
@@ -20,6 +22,13 @@ clean:
 menuconfig:
 	- $(MAKE_CMD) -C firmware menuconfig
 
+install-boot:
+	- $(MAKE_CMD) EXTERNAL_BOARD_DIRS=$(CURDIR)/boards -C RIOT/bootloaders/riotboot_dfu flash
+	@echo Please connect in the DFU mode. Change to the port Target and them run:
+	@echo + make update
+
+update:
+	- FEATURES_REQUIRED=riotboot USEMODULE=usbus_dfu $(MAKE_CMD) M4ABOOT=1 -C firmware all riotboot/flash-slot0
 docs:
 	cd doc/doxygen && make
 

--- a/boards/doc.txt
+++ b/boards/doc.txt
@@ -47,23 +47,24 @@ This sets USB port with VID =1209, PID = 7D02.
 
 Below are the steps to update the firmware:
 
-- Compile with the following command
+Load the Bootloader firmware to the board
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make BOARD=m4a-24g
+make install-boot
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-with this you get a .bin file located at <project_folder>/bin
-
-### Firmware upgrade
-
-- Switch to USB port and run the following command in terminal:
+- Compile and flash the bootloader with the following command
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-dfu-util --device : --alt 0 --download [file.bin]
+sudo make update
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Every time that you run make update, you are uploading the firmware. Doesn matter
+if you're uploading by first time, the command install your firmware without errors
+
+@note: it's recommended run in sudo su or superuser with privileges to get
+access of the DFU device
 
 ## Notes:
 - Tested with dfu-util v0.9

--- a/boards/m4a-24g/Makefile.include
+++ b/boards/m4a-24g/Makefile.include
@@ -1,1 +1,10 @@
+PROGRAMMERS_SUPPORTED += dfu-util
+
+# Required elements to Bootloader_mode
+ifeq ($(M4ABOOT), 1)
+	FLASHFILE = $(BINFILE) -checksummed
+	FFLAGS = -d 1209:$(USB_PID),1209:7D02 -a 0 -D $(FLASHFILE)
+	PROGRAMMER = dfu-util
+endif
+
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/m4a-mb/Makefile.include
+++ b/boards/m4a-mb/Makefile.include
@@ -1,1 +1,10 @@
+PROGRAMMERS_SUPPORTED += dfu-util
+
+# Required elements to Bootloader_mode
+ifeq ($(M4ABOOT), 1)
+	FLASHFILE = $(BINFILE) -checksummed
+	FFLAGS = -d 1209:$(USB_PID),1209:7D02 -a 0 -D $(FLASHFILE)
+	PROGRAMMER = dfu-util
+endif
+
 include $(RIOTMAKE)/boards/sam0.inc.mk


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description

This Pr includes a makefile to be easier the build and dfu flashing an file. Integrate an own bootloader to Mesh4all that provides an Vendor_id and Product_id dedicated to Mesh4all Boards and bootloaders, compilers, itś applied an make variable to define the boot_update mode, the user dotń need to write it, it's conventional gives support to m4a-24g bootloader support features. in the makefile of firmware there are some parameters to define the dfu elements required, as vendor_id as the slot where will be uploaded the firmware. 

<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
only has to connect in EDBG USB and run:
```sh
make install-boot BOARD=m4a-24g
```
- updating your firmware
```sh
make update
```

You should could be run the `make update` how many times that you need to upload the firmware
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
