### PR TITLE
wifi-subsys/components: fixed Cmake conflicts with server_cert.pem

### DIFF
--- a/wifi-subsys/components/protocols/test/CMakeLists.txt
+++ b/wifi-subsys/components/protocols/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
                        REQUIRES protocols network storage unity esp-tls esp_http_client
-                       EMBED_TXTFILES ../server_root_cert.pem)
+                       )

--- a/wifi-subsys/components/tools/idf_component.yml
+++ b/wifi-subsys/components/tools/idf_component.yml
@@ -1,3 +1,0 @@
-## IDF Component Manager Manifest File
-dependencies:
-  espressif/cbor: "==0.5.4"

--- a/wifi-subsys/main/CMakeLists.txt
+++ b/wifi-subsys/main/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register( SRCS "main.c"
                         INCLUDE_DIRS "."
-                        REQUIRES network uart storage protocols)
+                        REQUIRES network uart storage protocols
+                        )


### PR DESCRIPTION

<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
In the wifi-subsys with the last updated was affected the test protocols, because was existing an conflict between the Embedded file server_root_cert.pem, it's been called two times by the protocols component and the test main.c
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
To test first build the main wifi-subsys firmware: 
```sh
idf.py build
```
if all it's done moves to /test folder and run:
```
idf.py build -D "TEST_COMPONENTS=protocols"
```
The expected results are the both files was built successfully. 

PD: the last update in the esp-idf version could affec also the cbor implementation, so the solution is do a submodule update. to run without require the dependencie .yml integrated 
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
