### PR TITLE
test/border_router: fixed with the new modifications

### DIFF
--- a/firmware/network/border_router/Makefile.dep
+++ b/firmware/network/border_router/Makefile.dep
@@ -1,5 +1,3 @@
-
-
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += auto_init_usbus
 USEMODULE += gnrc_icmpv6_echo

--- a/firmware/network/border_router/border_router.c
+++ b/firmware/network/border_router/border_router.c
@@ -39,7 +39,7 @@ int8_t get_wired_iface(void) {
     return -1;
 }
 
-int8_t border_router_setup(ipv6_addr_t addr, uint8_t iface_type) {
+int8_t border_router_setup(ipv6_addr_t addr, uint8_t prefix, uint8_t iface_type) {
     ipv6_addr_t ip;
     int8_t index;
     switch (iface_type) {
@@ -62,13 +62,13 @@ int8_t border_router_setup(ipv6_addr_t addr, uint8_t iface_type) {
         return -1;
     }
     if (ipv6_addr_is_global(&addr)) {
-        if (set_ipv6_global(index, addr) < 0) {
+        if (set_ipv6_global(index, addr, prefix) < 0) {
             return -1;
         }
         return 0;
     }
     if (ipv6_addr_is_multicast(&addr)) {
-        if (set_ipv6_multicast(index, addr) < 0) {
+        if (set_ipv6_multicast(index, addr, prefix) < 0) {
             return -1;
         }
         return 0;

--- a/firmware/network/border_router/include/border_router.h
+++ b/firmware/network/border_router/include/border_router.h
@@ -49,11 +49,11 @@ enum type_iface_t {
  *
  * @param[in] addr       ipv6 address
  * @param[in] iface_type refers to if is used a WIRED or WIRELESS interface.
- *
+ * @param[in] prefix Networks prefix,express the subnet size.
  * @retval 0 Setup Success
  * @retval -1 Setup Failed
  */
-int8_t border_router_setup(ipv6_addr_t addr, uint8_t iface_type);
+int8_t border_router_setup(ipv6_addr_t addr, uint8_t prefix, uint8_t iface_type);
 
 #ifdef __cplusplus
 }

--- a/firmware/network/net_tools/include/net_tools.h
+++ b/firmware/network/net_tools/include/net_tools.h
@@ -59,21 +59,23 @@ int8_t get_ipv6_global(kernel_pid_t iface_pid, ipv6_addr_t *addr);
  * @brief Function to set an ipv6 global address in an iface.
  *
  * @param[in] iface_index  index that will be save the ipv6 address.
- * @param[in] ip Address ipv6 global to set
- * @retval 0 Correctly set up of the @p ip in the interface
- * @retval -1 Couldn't set the @p ip address in the interface
+ * @param[in] ip Address ipv6 global to set.
+ * @param[in] prefix Networks prefix,express the subnet size.
+ * @retval 0 Correctly set up of the @p ip in the interface.
+ * @retval -1 Couldn't set the @p ip address in the interface.
  */
-int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip);
+int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip, uint8_t prefix);
 
 /**
  * @brief Function to set an ipv6 global address in an iface.
  *
  * @param[in] iface_index  index that will be save the ipv6 address.
  * @param[in] ip Address ipv6 multicast to set
+ * @param[in] prefix Networks prefix,express the subnet size.
  * @retval  0 Correctly set up of the @p ip in the interface.
  * @retval -1 Couldn't set the @p ip address in the interface.
  */
-int8_t set_ipv6_multicast(kernel_pid_t iface_index, ipv6_addr_t ip);
+int8_t set_ipv6_multicast(kernel_pid_t iface_index, ipv6_addr_t ip, uint8_t prefix);
 
 #ifdef __cplusplus
 }

--- a/firmware/network/net_tools/net_tools.c
+++ b/firmware/network/net_tools/net_tools.c
@@ -56,7 +56,13 @@ int8_t get_ipv6_global(kernel_pid_t iface_pid, ipv6_addr_t *addr) {
     return -1;
 }
 
-int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip) {
+int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip, uint8_t prefix) {
+    if (prefix > 128) {
+        printf("Wrong prefix length\n"
+               "File: %s, Function: %s, Line: %d\n",
+               __FILE__, __func__, __LINE__);
+    }
+    uint16_t flags = GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID | (prefix << 8U);
     netif_t *iface = netif_get_by_id(iface_index);
     if (!ipv6_addr_is_global(&ip)) {
         printf("The ipv6 address isn't a ipv6 global address format accepted\n"
@@ -64,8 +70,7 @@ int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip) {
                __FILE__, __func__, __LINE__);
         return -1;
     }
-    if (netif_set_opt(iface, NETOPT_IPV6_ADDR, GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID, &ip,
-                      sizeof(ipv6_addr_t)) < 0) {
+    if (netif_set_opt(iface, NETOPT_IPV6_ADDR, flags, &ip, sizeof(ipv6_addr_t)) < 0) {
         printf("error: unable to add IPv6 address\n"
                "File: %s, Function: %s, Line: %d\n",
                __FILE__, __func__, __LINE__);
@@ -74,15 +79,21 @@ int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip) {
     return 0;
 }
 
-int8_t set_ipv6_multicast(kernel_pid_t iface_index, ipv6_addr_t ip) {
+int8_t set_ipv6_multicast(kernel_pid_t iface_index, ipv6_addr_t ip, uint8_t prefix) {
+    if (prefix > 128) {
+        printf("Wrong prefix length\n"
+               "File: %s, Function: %s, Line: %d\n",
+               __FILE__, __func__, __LINE__);
+    }
+    uint16_t flags = GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID | (prefix << 8U);
     netif_t *iface = netif_get_by_id(iface_index);
-    if (ipv6_addr_is_multicast(&ip)) {
+    if (!ipv6_addr_is_multicast(&ip)) {
         printf("The ipv6 address isn't a ipv6 multicast address format accepted\n"
                "File: %s, Function: %s, Line: %d\n",
                __FILE__, __func__, __LINE__);
         return -1;
     }
-    if (netif_set_opt(iface, NETOPT_IPV6_GROUP, 0, &ip, sizeof(ipv6_addr_t)) < 0) {
+    if (netif_set_opt(iface, NETOPT_IPV6_GROUP, flags, &ip, sizeof(ipv6_addr_t)) < 0) {
         printf("error: unable to join IPv6 multicast group\n"
                "File: %s, Function: %s, Line: %d\n",
                __FILE__, __func__, __LINE__);

--- a/tests/border_router/main.c
+++ b/tests/border_router/main.c
@@ -17,36 +17,36 @@
  * @brief       border router test file
  *
  * @author      RocioRojas <Rociorojas391@gmail.com>
+ * @author      eduazocar <eduazocarv@gmail.com>
  */
 
 #include <string.h>
 #include <errno.h>
 #include "embUnit.h"
 #include "border_router.h"
-#include "rpl_protocol.h"
 
-void test_border_router_add_ipv6(void) {
-     ipv6_addr_t address = {
+void test_border_router_setup_wired(void) {
+    ipv6_addr_t address = {
         .u8 = {0},
     };
-    ipv6_addr_from_str(&address, "2001:db8:1::2");
-    int err = border_router_add_ipv6(_UNICAST,  &address, WIRED_INTERFACE);
+    ipv6_addr_from_str(&address, "2001:db8:2::1");
+    int err = border_router_setup(address, 64, WIRED_INTERFACE);
     TEST_ASSERT_EQUAL_INT(0, err);
 }
 
-void test_border_router_add_ipv6_node(void) {
-     ipv6_addr_t address = {
+void test_border_router_setup_wireless(void) {
+    ipv6_addr_t address = {
         .u8 = {0},
     };
     ipv6_addr_from_str(&address, "2001:db8:1::2");
-    int err = border_router_add_ipv6(_UNICAST,  &address, WIRELESS_INTERFACE);
+    int err = border_router_setup(address, 16, WIRELESS_INTERFACE);
     TEST_ASSERT_EQUAL_INT(0, err);
 }
 
 Test *tests_border_router(void) {
     EMB_UNIT_TESTFIXTURES(fixtures){
-        new_TestFixture(test_border_router_add_ipv6),
-        new_TestFixture(test_border_router_add_ipv6_node),
+        new_TestFixture(test_border_router_setup_wired),
+        new_TestFixture(test_border_router_setup_wireless),
     };
 
     EMB_UNIT_TESTCALLER(tests_border_router, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
These are some modifications to give support with the net_tools changes to the border_router test, in this moment the test is printing the next information:
```
2022-06-10 07:27:28,311 # main(): This is RIOT! (Version: 2021.10-devel-4249-g5f574-HEAD)
2022-06-10 07:27:28,312 # .0x114f
2022-06-10 07:27:28,314 # *** RIOT kernel panic:
2022-06-10 07:27:28,315 # FAILED ASSERTION.
2022-06-10 07:27:28,316 # 
2022-06-10 07:27:28,316 # *** halted.
2022-06-10 07:27:28,317 # 
2022-06-10 07:27:28,317 # 
2022-06-10 07:27:28,319 # Context before hardfault:
2022-06-10 07:27:28,321 #    r0: 0x0000000a
2022-06-10 07:27:28,322 #    r1: 0x00000000
2022-06-10 07:27:28,324 #    r2: 0xc0000000
2022-06-10 07:27:28,325 #    r3: 0x00000000
2022-06-10 07:27:28,327 #   r12: 0x00000028
2022-06-10 07:27:28,329 #    lr: 0x00001223
2022-06-10 07:27:28,330 #    pc: 0x00001bb2
2022-06-10 07:27:28,332 #   psr: 0x61000000
2022-06-10 07:27:28,332 # 
2022-06-10 07:27:28,332 # Misc
2022-06-10 07:27:28,334 # EXC_RET: 0xfffffffd
2022-06-10 07:27:28,337 # Active thread: 7 "cdcecm"
2022-06-10 07:27:28,341 # Attempting to reconstruct state for debugging...
2022-06-10 07:27:28,342 # In GDB:
2022-06-10 07:27:28,343 #   set $pc=0x1bb2
2022-06-10 07:27:28,344 #   frame 0
2022-06-10 07:27:28,345 #   bt
2022-06-10 07:27:28,346 # Inside isr -13
2022-06-10 08:05:09,033 # Exiting Pyterm
```
I think that could be failing by the submodule changes
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
```
make -C test/border_router flash term
```
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fix #269 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
