### PR TITLE
Network: Made kconfig to ds18 and moisture sensor

### DIFF
--- a/examples/moisture_sensor_hw390/Kconfig
+++ b/examples/moisture_sensor_hw390/Kconfig
@@ -1,0 +1,1 @@
+rsource "../../firmware/peripherals/moisture_sensor/Kconfig"

--- a/examples/moisture_sensor_hw390/main.c
+++ b/examples/moisture_sensor_hw390/main.c
@@ -26,7 +26,7 @@
 #include "periph/adc.h"
 #include "ztimer.h"
 
-#define RES             ADC_RES_10BIT
+#define RES             CONFIG_ADC_RES
 #define DELAY_MS        5000U
 
 int main (void) {

--- a/firmware/peripherals/Kconfig
+++ b/firmware/peripherals/Kconfig
@@ -1,9 +1,4 @@
 menu "Peripherals"
-menu "Hardware Periph Setup"
-if BOARD_M4A_24G
-rsource "../../boards/m4a-24g/Kconfig.periph"
-endif
-endmenu
-rsource "ds18_sensor/Kconfig"
-rsource "moisture_sensor/Kconfig"
+    rsource "ds18_sensor/Kconfig"
+    rsource "moisture_sensor/Kconfig"
 endmenu

--- a/firmware/peripherals/ds18_sensor/Kconfig
+++ b/firmware/peripherals/ds18_sensor/Kconfig
@@ -1,10 +1,5 @@
 menu "ds18 for soil"
-# Set if the ds18 for soil is connected
-config DS18_SOIL_CONNECTED
-    bool "Set if it's connected"
-    default y
-# Set the GPIO where it's connected
-config DS18_SOIL_GPIO
-    int "GPIO where the ds18 is attached"
-    default 0
+    config PIN_TEMP_SENSOR
+    int "Pin to connect temperature sensor"
+    default 5
 endmenu

--- a/firmware/peripherals/moisture_sensor/Kconfig
+++ b/firmware/peripherals/moisture_sensor/Kconfig
@@ -1,3 +1,34 @@
 menu "Moisture sensor setup"
+choice ADC_RES
+    prompt "ADC_BITS_RESOLUTION"
+    default ADC_RES_10BIT
 
+config ADC_RES_6BIT
+    bool "ADC resolution: 6 bit"
+
+config ADC_RES_8BIT
+    bool "ADC resolution: 8 bit"
+
+config ADC_RES_10BIT
+    bool "ADC resolution: 10 bit"
+
+config ADC_RES_12BIT
+    bool "ADC resolution: 12 bit"
+
+config ADC_RES_14BIT
+    bool "ADC resolution: 14 bit"
+
+config ADC_RES_1B6IT
+    bool "ADC resolution: 16 bit"
+endchoice
+
+config ADC_RES
+int
+
+default 255 if ADC_RES_6BIT
+default 48 if ADC_RES_8BIT
+default 32 if ADC_RES_10BIT
+default 0 if ADC_RES_12BIT
+default 254 if ADC_RES_14BIT
+default 253 if ADC_RES_16BIT
 endmenu

--- a/firmware/peripherals/moisture_sensor/moisture_sensor.c
+++ b/firmware/peripherals/moisture_sensor/moisture_sensor.c
@@ -24,7 +24,7 @@
 
 #define DEFAULT_MIN 356
 #define DEFAULT_MAX 880
-#define RES ADC_RES_10BIT
+#define RES (CONFIG_ADC_RES)
 
 int init_moisture (void)
 {

--- a/tests/ds18/Kconfig
+++ b/tests/ds18/Kconfig
@@ -1,0 +1,1 @@
+rsource "../../firmware/peripherals/ds18_sensor/Kconfig"

--- a/tests/ds18/main.c
+++ b/tests/ds18/main.c
@@ -26,7 +26,7 @@
 #include "ds18_sensor.h"
 
 void test_init_ds18(void) {
-    int err = init_temperature_sensor(5);
+    int err = init_temperature_sensor(CONFIG_PIN_TEMP_SENSOR);
 
     TEST_ASSERT_EQUAL_INT(0, err);
 }


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
Made kconfig to ds18 and moisture sensor module with the kconfig sets the configuration to pin for ds18 module and values default of moisture sensor.
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure


Run in terminal make menuconfig, look for the option ds18 or moisture sensor.
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
