### PR TITLE
Network: Made kconfig to at_client

### DIFF
--- a/firmware/sys/at_client/Kconfig
+++ b/firmware/sys/at_client/Kconfig
@@ -1,3 +1,6 @@
 menu "AT Client"
-# TO DO
+    config WAIT_RESPONSE
+    int "SECONDS TO WAIT RESPONSE"
+    default 10
+    range 10 20
 endmenu

--- a/firmware/sys/at_client/at_client.c
+++ b/firmware/sys/at_client/at_client.c
@@ -37,7 +37,7 @@
 
 #define PRIORITY (THREAD_PRIORITY_MAIN - 1)
 #define QUEUE_SIZE (8)
-#define WAIT_RESPONSE (10 * US_PER_SEC) // time in microseconds
+#define WAIT_RESPONSE (US_PER_SEC * CONFIG_WAIT_RESPONSE) // time in microseconds
 
 kernel_pid_t buff_thread_pid;
 char stack[THREAD_STACKSIZE_MAIN];

--- a/firmware/sys/at_client/include/at_client.h
+++ b/firmware/sys/at_client/include/at_client.h
@@ -26,7 +26,7 @@
 #define AT_CLIENT_H
 
 #define SHELL_BUFSIZE (128U) /*!< Size of shell buffer*/
-#define UART_BUFSIZE (256U)  /*!< Size of uart buffer*/
+#define UART_BUFSIZE (256U)   /*!< Size of uart buffer*/
 
 #include "ringbuffer.h"
 #include <stdio.h>

--- a/tests/at_client_test/Kconfig
+++ b/tests/at_client_test/Kconfig
@@ -1,0 +1,1 @@
+rsource "../../firmware/sys/at_client/Kconfig"


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
Made kconfig to at client module with the kconfig sets the configuration to baudrate default, shell and uart buff size

<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
Run in terminal ```make menuconfig```, look for the option at client and choose baudrate default, shell and uart buff size
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
