### PR TITLE
Storage: compress model to flashpages blocks

### DIFF
--- a/firmware/sys/storage/Makefile.dep
+++ b/firmware/sys/storage/Makefile.dep
@@ -1,4 +1,5 @@
 USEMODULE += mtd_flashpage
+USEMODULE += mtd_write_page
 
 ifneq (,$(filter storage,$(USEMODULE)))
   FEATURES_REQUIRED += periph_flashpage

--- a/firmware/sys/storage/include/storage.h
+++ b/firmware/sys/storage/include/storage.h
@@ -15,13 +15,15 @@
  */
 
 /**
- * @ingroup     storage
+ * @ingroup     storage_module
  * @{
+ * @file
  * @brief       This is the storage module where you can save data in the flash memory.
  *              This data should not be greater than 64 bytes. Data formats allowed are string
  *              and uint8.
  *
  * @author      xkevin190 <kevinvelasco193@gmail.com>
+ * @author      eduazocar <eduazocarv@gmail.com>
  *
  */
 #ifndef STORAGE_H
@@ -33,15 +35,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define    LAST_PAGE 1
-
-/**
- * @brief This is the number of pages that we can write
+#define LAST_AVAILABLE_PAGE (FLASHPAGE_NUMOF - 1) /*!< Last position in the block EEPROM*/
+#define MAX_SIZE_STORAGE (FLASH_PAGE_SIZE)        /*!< max size to save in the page */
+#define MAX_NUMOF_FLASHPAGES                                                                       \
+    (FLASHPAGE_PAGES_PER_ROW * FLASH_PAGE_SIZE) /*!< max num of pages that can be manipulated */
+/** @note The storage EEPROM section page could be resize with the bootloader block size
+ *  @warning Always the block EEPROM and BOOTLOADER are affected between them.
  */
-#define LAST_AVAILABLE_PAGE (FLASHPAGE_NUMOF - LAST_PAGE)
-#define MAX_SIZE_STORAGE 16 /*!< max size to save in the page */
-
 /**
  * @brief This function initializes all components needed to start and to save the data
  *
@@ -56,10 +56,35 @@ int mtd_start(void);
  *
  * @param [in] key  this is the address where will be saved the data in the memory
  * @param [out] value value to save
- * @return  0 Satisfactory result
- *          -1 Failed result
+ * @retval 0 Satisfactory result
+ * @retval -1 Failed result
  */
 int mtd_save(uint32_t key, void *value);
+
+/**
+ * @brief This function is executed to save any data type or any strutc, The function saves all the
+ * information compressed in EEPROM/FLASH_MEMORY. The data is stored in each page of the
+ * EEPROM/MEMORY_FLASH section.
+ * @warning: The EEPROM/FLASH_MEMORY section size depends of itself hardware.
+ *
+ * @param [in]  value The input value given could be any datatype or data struct
+ * @param [in]  len  size of the all elements in the container of @p value
+ * @retval  0 Satisfactory result
+ * @retval  -1 Failed result
+ */
+int mtd_save_compress(void *value, uint16_t len);
+
+/**
+ * @brief load all data in the storage, depending of the number of bytes ( @p len ) required to read
+ * from the storage block in the mtd device.
+ *
+ * @param [out]  value pointer to an struct or variable where will be loaded the data of the
+ * storage.
+ * @param [in]  len  size of the struct or variable @p value
+ * @retval  0 Satisfactory result
+ * @retval  -1 Failed result
+ */
+int mtd_load(void *value, uint16_t len);
 
 /**
  * @brief Function used to get the strings already saved

--- a/tests/storage/main.c
+++ b/tests/storage/main.c
@@ -18,24 +18,63 @@
  * @brief       storage file
  *
  * @author      xkevin190 <kevinvelasco193@gmail.com>
+ * @author      eduazocar <eduazocarv@gmail.com>
  */
 #include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
 #include <errno.h>
 
 #include "embUnit.h"
 
 #include "storage.h"
 
-#define ADDRESS (uint32_t) flashpage_addr(LAST_AVAILABLE_PAGE -5)
+#define ADDRESS (uint32_t) flashpage_addr(LAST_AVAILABLE_PAGE - 5)
 
 char data[] = "hello world";
 uint8_t u8value = 150;
+
+struct val {
+    uint8_t var[6];
+    uint32_t var2[6];
+    char str[28];
+    int32_t var3[5];
+};
 
 void test_init_mtd(void) {
     int ret = mtd_start();
     TEST_ASSERT_EQUAL_INT(0, ret);
 }
 
+void test_save_data(void) {
+    int ret = 0;
+    struct val test_save = {.var = {2, 5, 6, 7, 8, 9},
+                            .var2 = {1555, 2556, 477, 8975, 987, 414},
+                            .str = "Welcome to mesh storage!!!",
+                            .var3 = {1550, 5544, -698, -789, -97852}};
+    printf("\nSaving data:\n");
+    mtd_save_compress(&test_save, sizeof(test_save));
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+void test_load_data(void) {
+    struct val test_load;
+    printf("\n\nLoading data:\n\n");
+    mtd_load(&test_load, sizeof(test_load));
+    for (uint16_t i = 0; i < ARRAY_SIZE(test_load.var); i++) {
+        printf("varui8_attr1 [%d]: %d\n", i + 1, test_load.var[i]);
+    }
+    printf("\n");
+    for (uint16_t i = 0; i < ARRAY_SIZE(test_load.var2); i++) {
+        printf("varui32_attr2 [%d]: %" PRId32 "\n", i + 1, test_load.var2[i]);
+    }
+    printf("\n");
+    printf("varstr_attr3: %s\n\n", test_load.str);
+    for (uint16_t i = 0; i < ARRAY_SIZE(test_load.var3); i++) {
+        printf("vari32_attr4 [%d]: %" PRId32 "\n", i + 1, test_load.var3[i]);
+    }
+    printf("\n");
+}
 void test_write_string(void) {
     int ret = mtd_write_string(ADDRESS, data);
     TEST_ASSERT_EQUAL_INT(0, ret);
@@ -72,7 +111,8 @@ void test_erase_address(void) {
 
 Test *tests_mtd_flashpage_tests(void) {
     EMB_UNIT_TESTFIXTURES(fixtures){
-        new_TestFixture(test_init_mtd),    new_TestFixture(test_write_string),
+        new_TestFixture(test_init_mtd),    new_TestFixture(test_save_data),
+        new_TestFixture(test_load_data),   new_TestFixture(test_write_string),
         new_TestFixture(test_read_string), new_TestFixture(test_write_u8),
         new_TestFixture(test_read_u8),     new_TestFixture(test_erase_address),
     };


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
This PR implement a solution to compress the data blocks in a flashpage of mtd.  The actually module presents a change in `mtd_save`, and `mtd_load`, here will be the save a defined struct or variable by the storage block
*note*: the current mode saves the data in the respective order, this means that when it's necessary read the data, you will received it in the same order that was saved.

### features added:

- Support to compressed mode --> (This will allow use correctly the memory size distribution)
- Support to load storage --> (Allow load all data compressed in the storage).
- Better definition of the `MAX_SIZE_STORAGE`,  `MAX_NUMOF_FLASHPAGES`, `LAST_AVAILABLE_PAGE`
- The initialization of device was fixed making the param `_pages persector` take the value of `FLASH_PAGES_PER_ROW`  
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
go to test
```
make -C test/storage flash term
```

### Expected Results:

```
2022-07-11 01:35:13,393 # START
2022-07-11 01:35:13,399 # main(): This is RIOT! (Version: 2022.07-devel-934-g6b7d8-HEAD)
2022-07-11 01:35:13,399 # ..
2022-07-11 01:35:13,400 # Saving data:
2022-07-11 01:35:13,404 # .
2022-07-11 01:35:13,404 # 
2022-07-11 01:35:13,405 # Loading data:
2022-07-11 01:35:13,405 # 
2022-07-11 01:35:13,407 # varui8_attr1 [1]: 2
2022-07-11 01:35:13,409 # varui8_attr1 [2]: 5
2022-07-11 01:35:13,411 # varui8_attr1 [3]: 6
2022-07-11 01:35:13,412 # varui8_attr1 [4]: 7
2022-07-11 01:35:13,414 # varui8_attr1 [5]: 8
2022-07-11 01:35:13,416 # varui8_attr1 [6]: 9
2022-07-11 01:35:13,416 # 
2022-07-11 01:35:13,418 # varui32_attr2 [1]: 1555
2022-07-11 01:35:13,421 # varui32_attr2 [2]: 2556
2022-07-11 01:35:13,423 # varui32_attr2 [3]: 477
2022-07-11 01:35:13,425 # varui32_attr2 [4]: 8975
2022-07-11 01:35:13,427 # varui32_attr2 [5]: 987
2022-07-11 01:35:13,429 # varui32_attr2 [6]: 414
2022-07-11 01:35:13,429 # 
2022-07-11 01:35:13,433 # varstr_attr3: Welcome to mesh storage!!!
2022-07-11 01:35:13,433 # 
2022-07-11 01:35:13,435 # vari32_attr4 [1]: 1550
2022-07-11 01:35:13,437 # vari32_attr4 [2]: 5544
2022-07-11 01:35:13,439 # vari32_attr4 [3]: -698
2022-07-11 01:35:13,441 # vari32_attr4 [4]: -789
2022-07-11 01:35:13,443 # vari32_attr4 [5]: -97852
2022-07-11 01:35:13,444 # 
2022-07-11 01:35:13,460 # ..68 65 6c 6c 6f 20 77 6f 72 6c 64 0 96 0 0 0 c8 14 0 20 1 0 0 0 b4 9 0 20 40 0 0 0 1 0 0 0 2 0 0 0 0 0 0 0 4c 48 0 0 0 4 0 0 4 0 0 0 40 0 0 0 10 0 0 0 
```

<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
