### PR TITLE
ci: update labeler runner with new board's label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -50,5 +50,11 @@
 "Platform: m4a-mb":
   - "boards/m4a-mb/**/*"
 
+"Platform: meshme":
+  - "boards/meshme/**/*"
+
 "Platform: native":
  - "boards/native/**/*"
+
+ "Platform: vs203":
+ - "boards/vs203/**/*"


### PR DESCRIPTION
### Contribution description
The labeler runner assigns labels according to the `labeler.yml` file when a new pr is opened or updated,  in a past PRs a new board was added, this pr takes into account those changes adding the labels; `Platform: meshme` and `Platform: vs203` for a future PR.

### Testing procedure
The labeler runner assigns labels according to the `labeler.yml` file, so new labels should appear in future PRs
or look the new changes in `labeler.yml` under `.gtihub` path

### Issues/PRs references
None