### PR TITLE
Meshboot: Supporting to install boot in meshme and vs203 boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ else
 	MAKE_CMD := make
 endif
 
+#Bootloaders params
+
+ifneq (,$(filter meshme vs203,$(BOARD)))	# Unsupported board without periph/usbdev (DFU not supported)
+	BOOTLOADER_DIR := RIOT/bootloaders/riotboot
+else
+	BOOTLOADER_DIR := RIOT/bootloaders/riotboot_dfu
+endif
+
 all:
 	- $(MAKE_CMD) -C firmware
 
@@ -23,12 +31,18 @@ menuconfig:
 	- $(MAKE_CMD) -C firmware menuconfig
 
 install-boot:
-	- $(MAKE_CMD) EXTERNAL_BOARD_DIRS=$(CURDIR)/boards -C RIOT/bootloaders/riotboot_dfu flash
+	- $(MAKE_CMD) EXTERNAL_BOARD_DIRS=$(CURDIR)/boards -C $(BOOTLOADER_DIR) flash
 	@echo Please connect in the DFU mode. Change to the port Target and them run:
 	@echo + make update
 
+ifneq (,$(filter meshme vs203,$(BOARD)))
+update:
+	- FEATURES_REQUIRED=riotboot $(MAKE_CMD) M4ABOOT=1 -C firmware all riotboot/flash-slot0
+else
 update:
 	- FEATURES_REQUIRED=riotboot USEMODULE=usbus_dfu $(MAKE_CMD) M4ABOOT=1 -C firmware all riotboot/flash-slot0
+endif
+
 docs:
 	cd doc/doxygen && make
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -26,7 +26,6 @@ USEMODULE += ps
 # Custom modules
 # Note: this code is hardware independent but "COULD BE" configurable for a
 #	target board
-USEMODULE += storage
 USEMODULE += rpl_protocol
 PSEUDOMODULES += 6lpan_node
 

--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -1,0 +1,31 @@
+# If no BOARD is found in the environment, use this default:
+# Select the boards with riotboot feature
+FEATURES_REQUIRED += riotboot
+
+# Include modules to test the bootloader
+USEMODULE += riotboot_slot
+USEMODULE += shell
+# Add shell_commands to use the shell version of `test_utils_interactive_sync`
+USEMODULE += shell_commands
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# Ensure both slot bin files are always generated and linked to avoid compiling
+# during the test. This ensures that "BUILD_IN_DOCKER=1 make test"
+# can rely on them being present without having to trigger re-compilation.
+BUILD_FILES += $(SLOT_RIOT_ELFS:%.elf=%.bin)
+
+# The test needs the linked slot binaries without header in order to be able to
+# create final binaries with specific APP_VER values. The CI RasPi test workers
+# don't compile themselves, thus add the required files here so they will be
+# submitted along with the test jobs.
+TEST_EXTRA_FILES=$(SLOT_RIOT_ELFS)
+
+include ../Makefile.tests_common
+include $(RIOTBASE)/Makefile.include

--- a/tests/riotboot/Makefile.ci
+++ b/tests/riotboot/Makefile.ci
@@ -1,0 +1,4 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    slstk3400a \
+    stk3200 \
+    #

--- a/tests/riotboot/README.md
+++ b/tests/riotboot/README.md
@@ -1,0 +1,40 @@
+RIOT bootloader test
+====================
+
+This is a basic example how to use RIOT bootloader in your embedded
+application.
+
+This test should foremost give you an overview how to use riotboot:
+
+  - `make all` build the test using the target riotboot, which generates
+  a binary file of the application with a header on top of it, used by
+  the bootloader to recognise a bootable image.
+
+  - `make riotboot/flash` creates the binary files and flashes both
+  riotboot and the RIOT image with headers included. This should boot
+  as a normal application.
+
+In this test two modules `riotboot_hdr` and `riotboot_slot` are used to showcase
+the access to riotboot shared functions.
+
+Automatic test
+==============
+
+This application's "test" target can be used to test basic riotboot
+functionality:
+
+    BOARD=<board> make flash test
+
+This will:
+
+1. flash bootloader and slot0, invalidate slot1
+2. get the running slot and current APP_VER
+
+3. flash slot1 with APP_VER + 1
+4. verify slot1 has booted and shows version = APP_VER + 1
+
+5. flash slot0 with APP_VER + 2
+4. verify slot0 has booted and shows version = APP_VER + 2
+
+If this test runs correctly, it shows that riotboot's basic functions are
+working properly on the target board.

--- a/tests/riotboot/main.c
+++ b/tests/riotboot/main.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2018 Inria
+ *                    Federico Pellegrin <fede@evolware.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       riotboot bootloader test
+ *
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ * @author      Federico Pellegrin <fede@evolware.org>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "riotboot/slot.h"
+#include "shell.h"
+
+static int cmd_show_slot_nr(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    printf("Current slot=%d\n", riotboot_slot_current());
+    return 0;
+}
+
+static int cmd_show_slot_hdr(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    int current_slot = riotboot_slot_current();
+    riotboot_slot_print_hdr(current_slot);
+    return 0;
+}
+
+static int cmd_show_slot_addr(int argc, char **argv)
+{
+    (void)argc;
+
+    int reqslot=atoi(argv[1]);
+    printf("Slot %d address=0x%08" PRIx32 "\n",
+           reqslot, riotboot_slot_get_image_startaddr(reqslot));
+    return 0;
+}
+
+static int cmd_dumpaddrs(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    riotboot_slot_dump_addrs();
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "showslot", "Print current slot number", cmd_show_slot_nr },
+    { "showhdr", "Print current slot header", cmd_show_slot_hdr },
+    { "showslotaddr", "Print address of requested slot", cmd_show_slot_addr },
+    { "dumpaddrs", "Prints all slot data in header", cmd_dumpaddrs },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    int current_slot;
+
+    puts("Hello Mesh-boot!");
+
+    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
+    printf("This board features a(n) %s MCU.\n", RIOT_MCU);
+
+    /* print some information about the running image */
+    current_slot = riotboot_slot_current();
+    if (current_slot != -1) {
+        printf("riotboot_test: running from slot %d\n", current_slot);
+        riotboot_slot_print_hdr(current_slot);
+    }
+    else {
+        printf("[FAILED] You're not running riotboot\n");
+    }
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}

--- a/tests/riotboot/tests/01-run.py
+++ b/tests/riotboot/tests/01-run.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Federico Pellegrin <fede@evolware.org>
+# Copyright (C) 2019 Francisco Molina <francois-xavier.molina@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import subprocess
+from testrunner import run
+from testrunner.spawn import MAKE
+
+
+class RiotbootDevice:
+    def __init__(self):
+        self.slot_num = None
+        self.app_ver = None
+
+    def flash_current_slot_and_app_ver(self):
+        cmd = [
+            MAKE,
+            "RIOTBOOT_SKIP_COMPILE=1",
+            "riotboot/flash-slot{}".format(self.slot_num),
+            "APP_VER={}".format(self.app_ver),
+        ]
+        assert(self.slot_num is not None)
+        assert(self.app_ver is not None)
+        assert subprocess.call(cmd) == 0
+
+    def get_current_slot_and_app_ver(self, child):
+        # Ask for current slot, should be 0 or 1
+        child.expect_exact('>')
+        child.sendline("showslot")
+        child.expect(r"Current slot=([0-1])")
+        self.slot_num = int(child.match.group(1))
+
+        # Ask for current APP_VER
+        child.expect_exact('>')
+        child.sendline("showhdr")
+        child.expect(r"Image Version: (?P<app_ver>0x[0-9a-fA-F]{8})\r\n")
+        self.app_ver = int(child.match.group("app_ver"), 16)
+
+    def check_current_slot_and_app_ver(self, child):
+        # Check if it's running on the expected slot
+        child.expect_exact('>')
+        child.sendline("showslot")
+        child.expect_exact("Current slot={}".format(self.slot_num))
+
+        # Ask for current slot header info and check for basic output integrity
+        child.expect_exact('>')
+        child.sendline("showhdr")
+        # Magic number is "RIOT" (always in little endian)
+        child.expect_exact("Image magic_number: 0x544f4952")
+        # Other info is hardware/app dependent so we just check basic compliance
+        child.expect_exact("Image Version: {0:#0{1}x}".format(self.app_ver, 10))
+        child.expect(r"Image start address: 0x[0-9a-fA-F]{8}\r\n")
+        child.expect(r"Header chksum: 0x[0-9a-fA-F]{8}\r\n")
+
+        # Ask for address of slot 0
+        child.expect_exact('>')
+        child.sendline("showslotaddr 0")
+        child.expect(r"Slot 0 address=0x[0-9a-fA-F]{8}\r\n")
+
+        # Ask for data of all slots
+        child.expect_exact('>')
+        child.sendline("dumpaddrs")
+        child.expect(r"slot 0: metadata: 0x[0-9a-fA-F]{1,8} "
+                     r"image: 0x[0-9a-fA-F]{8}\r\n")
+        child.expect(r"slot 1: metadata: 0x[0-9a-fA-F]{1,8} "
+                     r"image: 0x[0-9a-fA-F]{8}\r\n")
+        child.expect_exact('>')
+
+
+def testfunc():
+    # This test requires flashing slot binaries. Some flashers like
+    # cc2538-bsl need to attach to the serial terminal in order to be
+    # able to flash. Since `run(func)` spawns a terminal a different
+    # `run(func)` is called after every flash in order to detach and
+    # re-attach the terminal between flashes
+    dev = RiotbootDevice()
+    # Get the current slot number and application version
+    ret = run(dev.get_current_slot_and_app_ver)
+    if ret != 0:
+        return ret
+
+    # flash to both slots and verify
+    for version in [dev.app_ver + 1, dev.app_ver + 2]:
+        # update slot number and application version
+        dev.slot_num = dev.slot_num ^ 1
+        dev.app_ver = version
+        # flash
+        dev.flash_current_slot_and_app_ver()
+        # verify its running from the correct slot with the right version
+        ret = run(dev.check_current_slot_and_app_ver)
+        if ret != 0:
+            return ret
+
+    print("TEST PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(testfunc())


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
This PR lets, to use riotboot serial in the new boards meshme and vs203, while both boards doesn´t have an `periph/usbdev`, the mode DFU is unsupported. This PR adds an new test model to run riotboot (test/meshboot). Here is a mode to test the bootloader works correctly with the new boards
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
Firmware testing procedure: (ATomatization of Bootloader with the firmware)
Run the make `install boot`
```
make install-boot BOARD=meshme
```
next step is update your firmware with any change:
```
make update BOARD=meshme
```

Running the test meshboot:
```
BOARD=meshme make -C flash test
```
*note*: this test run in m4a-24g by default, you need to asign the new boards as value of enviroment variable `BOARD` 

<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fixes #296 .
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc
Fixes #
See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
