### PR TITLE
ci: add new platforms to  drone runners

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,3 +29,35 @@ trigger:
   event:
     - push
     - pull_request
+
+---
+kind: pipeline
+type: docker
+name: meshme
+steps:
+  - name: build
+    image: luisan00/m4abuild-base:latest
+    commands:
+      - git submodule update --init --recursive
+      - make -C firmware BOARD=meshme
+
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+kind: pipeline
+type: docker
+name: vs203
+steps:
+  - name: build
+    image: luisan00/m4abuild-base:latest
+    commands:
+      - git submodule update --init --recursive
+      - make -C firmware BOARD=vs203
+
+trigger:
+  event:
+    - push
+    - pull_request


### PR DESCRIPTION
### Contribution description
Recently was added cc2538 in two flavors to the `drone` runners, this PR add  these two boards to the drone's test

### Testing procedure

Nothing special, when a new PR is open, updated or merged look at the runners list and search the luke/skywalker's details, the "matrix build" should show you 4 builds/test:
- m4a-24g
- m4a-mb
- meshme
- vs203

### Issues/PRs references
None