### PR TITLE
boards/meshme: Add ADC support and tests

### DIFF
--- a/boards/meshme/board.c
+++ b/boards/meshme/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ * Copyright (c) 2022 Mesh4all mesh4all.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 
 /**
- * @file
+ * @file            board.c
  * @brief           Board specific implementations for the MeshMe board
- * @copyright       Copyright (c) 2022 Mesh for All (Mesh4all)
+ * @copyright       Copyright (c) 2022 Mesh4All hello@mesh4all.org
  */
 #include "board.h"
 #include "cpu.h"

--- a/boards/meshme/include/board.h
+++ b/boards/meshme/include/board.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Loci Controls Inc.
- * Copyright (C) 2022 Mesh4all <contact@mesh4all.org>
+ * Copyright (C) 2022 Mesh4all mesh4all.org
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -10,10 +10,8 @@
 /**
  * @ingroup     boards_meshme
  * @{
- *
- * @file
- * @brief       Board specific definitions for the MeshMe 24G20P
- *
+ * @file        board.h
+ * @brief       Board specific definitions for the Meshme board
  * @author      Ian Martin <ian@locicontrols.com>
  * @author      Luis A. Ruiz <luisan00@hotmail.com>
  */
@@ -32,22 +30,22 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN GPIO_PIN(PORT_C, 5)      /*!< LED-0 (?) routed to PC5 pin */
-#define LED0_ON gpio_set(LED0_PIN)        /*!< LED-0 On handler */
-#define LED0_OFF gpio_clear(LED0_PIN)     /*!< LED-0 Off handler */
-#define LED0_TOGGLE gpio_toggle(LED0_PIN) /*!< LED-0 Toggle handler */
+#define LED0_PIN GPIO_PIN(PORT_C, 5)      /*!< LED0 (?) routed to PC5 pin */
+#define LED0_ON gpio_set(LED0_PIN)        /*!< LED0 On handler */
+#define LED0_OFF gpio_clear(LED0_PIN)     /*!< LED0 Off handler */
+#define LED0_TOGGLE gpio_toggle(LED0_PIN) /*!< LED0 Toggle handler */
 
-#define LED1_PIN GPIO_PIN(PORT_C, 4)      /*!< LED-1 (green) routed to PC4 pin */
-#define LED1_ON gpio_set(LED1_PIN)        /*!< LED-1 On handler */
-#define LED1_OFF gpio_clear(LED1_PIN)     /*!< LED-1 Off handler */
-#define LED1_TOGGLE gpio_toggle(LED1_PIN) /*!< LED-1 Toggle handler */
+#define LED1_PIN GPIO_PIN(PORT_C, 4)      /*!< LED1 (green) routed to PC4 pin */
+#define LED1_ON gpio_set(LED1_PIN)        /*!< LED1 On handler */
+#define LED1_OFF gpio_clear(LED1_PIN)     /*!< LED1 Off handler */
+#define LED1_TOGGLE gpio_toggle(LED1_PIN) /*!< LED1 Toggle handler */
 
-#define LED2_PIN GPIO_PIN(PORT_C, 1)      /*!< LED 2 (orange) routed to PC1 pin */
+#define LED2_PIN GPIO_PIN(PORT_C, 1)      /*!< LED2 (orange) routed to PC1 pin */
 #define LED2_ON gpio_set(LED2_PIN)        /*!< LED2 On handler */
 #define LED2_OFF gpio_clear(LED2_PIN)     /*!< LED2 Off handler */
 #define LED2_TOGGLE gpio_toggle(LED2_PIN) /*!< LED2 Toggle handler */
 
-#define LED3_PIN GPIO_PIN(PORT_C, 0)      /*!< LED 3 (red) routed to PC0 pin */
+#define LED3_PIN GPIO_PIN(PORT_C, 0)      /*!< LED3 (red) routed to PC0 pin */
 #define LED3_ON gpio_set(LED3_PIN)        /*!< LED3 On handler */
 #define LED3_OFF gpio_clear(LED3_PIN)     /*!< LED3 Off handler */
 #define LED3_TOGGLE gpio_toggle(LED3_PIN) /*!< LED3 Toggle handler */
@@ -86,14 +84,14 @@ extern "C" {
  * @name    xtimer configuration
  * @{
  */
-#define XTIMER_WIDTH (16)       /*!< ToDo */
-#define XTIMER_BACKOFF (50)     /*!< ToDo */
-#define XTIMER_ISR_BACKOFF (40) /*!< ToDo */
+#define XTIMER_WIDTH (16)       /*!< TODO */
+#define XTIMER_BACKOFF (50)     /*!< TODO */
+#define XTIMER_ISR_BACKOFF (40) /*!< TODO */
 /** @} */
 
 /**
  * @name   RF Front-End configuration
- *
+ * @{
  * @brief The FE CC2592 is controlled by the CC2538 with 3 pins, both are connected as follow:
  *
  * | CC2538 (MCU) | CC2592 (FE) | Description                            |
@@ -102,8 +100,7 @@ extern "C" {
  * | PORT_C, 2    | LNA_EN      | Low Noise Amplifier (enabled/disabled) |
  * | PORT_C, 3    | PA_EN       | Power Amplifier (enabled/disabled)     |
  *
- * The CC2538 RF Core needs to use "observable signals" to drive the LNA_EN and the PA_EN pins
- * @{
+ * The CC2538 RF Core needs to use the "observable signals" to drive the LNA_EN and the PA_EN pins
  */
 #define CONFIG_CC2538_RF_OBS_SIG_0_PCX 3 /*!< tx active to PC3, it controls the PA */
 #define CONFIG_CC2538_RF_OBS_SIG_1_PCX 2 /*!< rx active to PC2, it controls the LNA */

--- a/boards/meshme/include/gpio_params.h
+++ b/boards/meshme/include/gpio_params.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 DAI Labor Technische Universität Berlin
- * Copyright (C) 2022 Mesh4all <contact@mesh4all.org>
+ * Copyright (C) 2022 Mesh4all mesh4all.org
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -10,11 +10,11 @@
 /**
  * @ingroup   boards_meshme
  * @{
- *
- * @file
+ * @file      gpio_params.h
  * @brief     Board specific configuration of direct mapped GPIOs
  *
  * @author    Anon Mall <anon.mall@gt-arc.com>
+ * @author    Luis A. Ruiz <luisan00@hotmail.com>
  */
 
 #ifndef GPIO_PARAMS_H

--- a/boards/meshme/include/periph_conf.h
+++ b/boards/meshme/include/periph_conf.h
@@ -28,7 +28,6 @@ extern "C" {
 
 #include "cpu.h"
 #include "periph_cpu.h"
-//#include "periph/cpuid.h"
 
 #include "cfg_clk_default.h"
 #include "cfg_timer_default.h"
@@ -70,7 +69,7 @@ extern "C" {
 /**
  * @brief Available ADC lines
  */
-static const adc_conf_t adc_config[] = { 
+static const adc_conf_t adc_config[] = {
     GPIO_PIN(PORT_A, 6), /*!< GPIO_PA6 as ADC input */
     GPIO_PIN(PORT_A, 7), /*!< GPIO_PA7 as ADC input */
 };

--- a/boards/meshme/include/periph_conf.h
+++ b/boards/meshme/include/periph_conf.h
@@ -11,11 +11,10 @@
  * @ingroup     boards_meshme
  * @{
  *
- * @file
- * @brief       Peripheral MCU configuration for the MeshMe board
- *
+ * @file        periph_conf.h
+ * @brief       Peripheral MCU configuration for the Meshme board
  * @author      Anon Mall <anon.mall@gt-arc.com>
- * @author      luisan00 <luisan00@hotmail.com>
+ * @author      Luis A. Ruiz <luisan00@hotmail.com>
  */
 
 #ifndef PERIPH_CONF_H
@@ -29,17 +28,59 @@ extern "C" {
 
 #include "cpu.h"
 #include "periph_cpu.h"
-#include "periph/cpuid.h"
+//#include "periph/cpuid.h"
 
 #include "cfg_clk_default.h"
 #include "cfg_timer_default.h"
 
 /**
- * @name    UART configuration
+ * @name    [A]nalog to [D]igital [C]onverter configuration
  * @{
  */
+/**
+ * @brief   Selected [default] voltage reference is [SOC_ADC_ADCCON3_EREF_EXT],
+ *          this can be changed according to the following table:
+ *
+ * | Register                   | Description                    |
+ * |:---------------------------|:-------------------------------|
+ * | SOC_ADC_ADCCON3_EREF_INT   | Internal reference             |
+ * | SOC_ADC_ADCCON3_EREF_EXT   | External reference on AIN7 pin |
+ * | SOC_ADC_ADCCON3_EREF_AVDD5 | AVDD5 pin                      |
+ * | SOC_ADC_ADCCON3_EREF_DIFF  | External reference on AIN6-AIN7 differential input |
+ *
+ * @note default is [SOC_ADC_ADCCON3_EREF_EXT]
+ */
+#define SOC_ADC_ADCCON3_EREF SOC_ADC_ADCCON3_EREF_AVDD5
 
 /**
+ * @brief   Selected default resolution is [ADC_RES_12BIT]
+ *          but it can be changed according the next table:
+ *
+ * | Register      | Description                  |
+ * |:--------------|:-----------------------------|
+ * | ADC_RES_7BIT  | 7 bits per sample resolution |
+ * | ADC_RES_9BIT  | 9 bits per sample    ""      |
+ * | ADC_RES_10BIT | 10 bits per sample   ""      |
+ * | ADC_RES_12BIT | 12 bits per sample   ""      |
+ *
+ * @note default is [ADC_RES_12BIT]
+ */
+#define SOC_ADC_RES ADC_RES_12BIT
+
+/**
+ * @brief Available ADC lines
+ */
+static const adc_conf_t adc_config[] = { 
+    GPIO_PIN(PORT_A, 6), /*!< GPIO_PA6 as ADC input */
+    GPIO_PIN(PORT_A, 7), /*!< GPIO_PA7 as ADC input */
+};
+
+#define ADC_NUMOF ARRAY_SIZE(adc_config) /*!< Number of available adc lines */
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
  * @brief   List of available UART ports, pins are mapped as follows:
  *
  * | UART Dev | TX pin | RX pin | CTS pin| RTS pin |

--- a/tests/periph_adc/Makefile
+++ b/tests/periph_adc/Makefile
@@ -1,0 +1,9 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_adc
+
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_adc/app.config.test
+++ b/tests/periph_adc/app.config.test
@@ -1,0 +1,11 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+# enable ADC peripheral driver
+CONFIG_MODULE_PERIPH_ADC=y
+
+# enable xtimer to wake up periodically
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y
+
+# enable stuffs related to tests
+CONFIG_MODULE_EMBUNIT=y

--- a/tests/periph_adc/doc.txt
+++ b/tests/periph_adc/doc.txt
@@ -1,0 +1,15 @@
+/**
+@defgroup      periph_adc
+@ingroup       test_group
+@{
+
+## Test the [A]nalog to [D]igital [C]onverter peripheral
+
+To test the code in automatic mode:
+
+```c
+make flash test
+```
+
+@}
+ */

--- a/tests/periph_adc/main.c
+++ b/tests/periph_adc/main.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 Mesh4all mesh4all.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @brief       ADC test
+ *
+ * @author      Luis A. Ruiz <luisan00@hotmail.com>
+ */
+#include <string.h>
+#include <errno.h>
+#include "periph/adc.h"
+#include "ztimer.h"
+#include "embUnit.h"
+
+#define RES ADC_RES_10BIT
+#define DELAY_MS 100U
+#define LAPS 5
+
+/* initialize all available ADC lines */
+void test_adc_init(void) {
+    int err;
+    for (unsigned i = 0; i < ADC_NUMOF; i++) {
+        if (adc_init(ADC_LINE(i)) < 0) {
+            printf("\nInitialization of ADC_LINE(%u) failed\n", i);
+            err = 1;
+        } else {
+            printf("\nSuccessfully initialized ADC_LINE(%u)\n", i);
+            printf("Channel %u of %u\n", i + 1, ADC_NUMOF);
+            err = 0;
+        }
+        ztimer_sleep(ZTIMER_MSEC, DELAY_MS);
+    }
+
+    TEST_ASSERT_EQUAL_INT(0, err);
+}
+
+void test_adc_read(void) {
+    int err;
+    int sample;
+    for (int lap = 0; lap < LAPS; lap++) {
+
+        printf("\nRound %d of %d\n", lap + 1, LAPS);
+
+        for (unsigned i = 0; i < ADC_NUMOF; i++) {
+            sample = adc_sample(ADC_LINE(i), RES);
+            if (sample < 0) {
+                printf("ADC_LINE(%u): selected resolution not applicable\n", i);
+                err = 1;
+            } else {
+                printf("ADC_LINE(%u): %i\n", i, sample);
+                err = 0;
+            }
+        }
+        ztimer_sleep(ZTIMER_MSEC, DELAY_MS);
+    }
+
+    TEST_ASSERT_EQUAL_INT(0, err);
+}
+
+Test *test_periph_adc(void) {
+
+    EMB_UNIT_TESTFIXTURES(fixtures){
+        new_TestFixture(test_adc_init), // init. ADC lines available
+        new_TestFixture(test_adc_read), // read value for each line
+    };
+
+    EMB_UNIT_TESTCALLER(test_periph_adc, NULL, NULL, fixtures);
+
+    return (Test *)&test_periph_adc;
+}
+int main(void) {
+    printf("Test ADC peripherals\n");
+    TESTS_START();
+    TESTS_RUN(test_periph_adc());
+    TESTS_END();
+    return 0;
+}

--- a/tests/periph_adc/tests/01-run.py
+++ b/tests/periph_adc/tests/01-run.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run_check_unittests
+
+if __name__ == "__main__":
+    sys.exit(run_check_unittests())


### PR DESCRIPTION
### Contribution description
This PR contains two **related** commits:
-  Add support for ADC peripheral on two lines of the `meshme` platform
-  `tests/periph_adc`

### Testing procedure
Run the `periph_adc` test with:
```sh
make BOARD=meshme flash test
```

### Issues/PRs references
None