### PR TITLE
firmware/storage: Fixed bug in Boards meshme and vs203

### DIFF
--- a/firmware/sys/storage/include/storage.h
+++ b/firmware/sys/storage/include/storage.h
@@ -36,9 +36,8 @@
 extern "C" {
 #endif
 #define LAST_AVAILABLE_PAGE (FLASHPAGE_NUMOF - 1) /*!< Last position in the block EEPROM*/
-#define MAX_SIZE_STORAGE (FLASH_PAGE_SIZE)        /*!< max size to save in the page */
-#define MAX_NUMOF_FLASHPAGES                                                                       \
-    (FLASHPAGE_PAGES_PER_ROW * FLASH_PAGE_SIZE) /*!< max num of pages that can be manipulated */
+#define MAX_SIZE_STORAGE (FLASHPAGE_SIZE)           /*!< max size to save in the page */
+#define MAX_NUMOF_FLASHPAGES FLASHPAGE_NUMOF      /*!< max num of pages that can be manipulated */
 /** @note The storage EEPROM section page could be resize with the bootloader block size
  *  @warning Always the block EEPROM and BOOTLOADER are affected between them.
  */

--- a/firmware/sys/storage/storage.c
+++ b/firmware/sys/storage/storage.c
@@ -29,7 +29,7 @@
 #include "storage.h"
 #include "mtd_flashpage.h"
 
-static mtd_flashpage_t _dev = MTD_FLASHPAGE_INIT_VAL(FLASHPAGE_PAGES_PER_ROW);
+static mtd_flashpage_t _dev = MTD_FLASHPAGE_INIT_VAL(8);
 static mtd_dev_t *dev = &_dev.base;
 
 int mtd_start(void) {
@@ -56,7 +56,7 @@ int mtd_save(uint32_t key, void *value) {
 int mtd_save_compress(void *value, uint16_t len) {
     uint8_t *ptr = value;
     uint8_t buf[MAX_SIZE_STORAGE];
-    uint8_t diff_size = MAX_SIZE_STORAGE;
+    uint16_t diff_size = MAX_SIZE_STORAGE;
     uint16_t num_pages = len / MAX_SIZE_STORAGE;
     uint8_t res_bits = len % MAX_SIZE_STORAGE;
     int8_t ret = 0;
@@ -83,7 +83,7 @@ int mtd_save_compress(void *value, uint16_t len) {
 
 int mtd_load(void *value, uint16_t len) {
     uint8_t *ptr = value;
-    uint8_t diff_size = MAX_SIZE_STORAGE;
+    uint16_t diff_size = MAX_SIZE_STORAGE;
     uint16_t num_pages = len / MAX_SIZE_STORAGE;
     uint8_t res_bits = len % MAX_SIZE_STORAGE;
     if ((num_pages < 1) || (res_bits != 0)) {


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
Contribution to provide support of storage module to new boards: was fixed reference to generic literals. FLASHPAGE_SIZE as `MAXIMUN_SIZE_STORAGE` and `MAX_NUMOF_FLASHPAGEs` as `FLASHPAGE_NUMOF`
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure

Testing with each board in test/storage

```
make -C tests/storage flash term
```
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
