### PR TITLE
boards/meshme: initial implementation of I2C and SPI peripherals

### DIFF
--- a/boards/meshme/include/periph_conf.h
+++ b/boards/meshme/include/periph_conf.h
@@ -48,6 +48,7 @@ extern "C" {
  * | SOC_ADC_ADCCON3_EREF_DIFF  | External reference on AIN6-AIN7 differential input |
  *
  * @note default is [SOC_ADC_ADCCON3_EREF_EXT]
+ * @see  periph_adc
  */
 #define SOC_ADC_ADCCON3_EREF SOC_ADC_ADCCON3_EREF_AVDD5
 
@@ -78,13 +79,16 @@ static const adc_conf_t adc_config[] = {
 /** @} */
 
 /**
- * @name    UART configuration
+ * @name    [U]niversal [A]synchronous [R]eceiver [T]ransmitter peripheral.
  * @{
- * @brief   List of available UART ports, pins are mapped as follows:
+ */
+/**
+ * @brief   Two available UART ports but only one is set as follows:
  *
  * | UART Dev | TX pin | RX pin | CTS pin| RTS pin |
- * |----------|--------|--------|--------|---------|
- * | 0        | PA0    | PA1    | Undef. | Undef.  |
+ * |:--------:|:------:|:------:|:------:|:-------:|
+ * | 0        | PA0    | PA1    | Undef  | Undef   |
+ * | ---      | ---    | ---    | ---    | ---     |
  *
  */
 static const uart_conf_t uart_config[] = {
@@ -101,6 +105,60 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR isr_uart0               /*!< interrupt function name mapping */
 #define UART_NUMOF ARRAY_SIZE(uart_config) /*!< Number of UARTs */
+/** @} */
+
+/**
+ * @name I2C Settings
+ * @{
+ */
+#define I2C_IRQ_PRIO 1 /*!< i2c IRQ priority */
+
+/**
+ * @brief   There are 2 I2C ports available but only one is set as follows:
+ *
+ * | \#  | SCL | SDA | Speed |
+ * |:---:|:---:|:---:|:-----:|
+ * | 0   | PB0 | PB1 | Fast  |
+ * | --- | --- | --- | ---   |
+ *
+ *  @note   I2C speed can be one of two modes available:
+ * - Standard 100 kbps
+ * - Fast 400 kbps
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .speed = I2C_SPEED_FAST,
+        .scl_pin = GPIO_PIN(PORT_B, 0),
+        .sda_pin = GPIO_PIN(PORT_B, 1),
+    },
+};
+#define I2C_NUMOF ARRAY_SIZE(i2c_config) /*!< Available i2c ports */
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+
+/**
+ * @brief There are 2 SPI ports available but only one is set as follows:
+ *
+ * | Num | MOSI | MISO | SCK | CS  |
+ * |:---:|:----:|:----:|:---:|:---:|
+ * | 0   | PB4  | PB5  | PB6 | PB7 |
+ * | --- | ---  | ---  | --- | --- |
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .num = 0,
+        .mosi_pin = GPIO_PIN(PORT_B, 4),
+        .miso_pin = GPIO_PIN(PORT_B, 5),
+        .sck_pin = GPIO_PIN(PORT_B, 6),
+        .cs_pin = GPIO_PIN(PORT_B, 7),
+    },
+};
+
+#define SPI_NUMOF ARRAY_SIZE(spi_config) /*!< Available SPI ports */
 /** @} */
 
 #ifdef __cplusplus

--- a/tests/doc.txt
+++ b/tests/doc.txt
@@ -1,5 +1,5 @@
 /**
-@defgroup tests Test
+@defgroup test_group Test
 
 ## Test documentation
 

--- a/tests/doc.txt
+++ b/tests/doc.txt
@@ -1,5 +1,5 @@
 /**
-@defgroup test_group Test
+@defgroup tests Test
 
 ## Test documentation
 

--- a/tests/driver_bme280/Makefile
+++ b/tests/driver_bme280/Makefile
@@ -1,0 +1,9 @@
+include ../Makefile.tests_common
+
+DRIVER ?= bme280_i2c
+
+USEMODULE += fmt
+USEMODULE += $(DRIVER)
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bme280/app.config.test
+++ b/tests/driver_bme280/app.config.test
@@ -1,0 +1,5 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_BMX280=y
+CONFIG_MODULE_BME280_I2C=y
+CONFIG_MODULE_FMT=y

--- a/tests/driver_bme280/doc.txt
+++ b/tests/driver_bme280/doc.txt
@@ -1,0 +1,7 @@
+/**
+* @defgroup      test_group_driver_bme280   Application test for bme280
+* @ingroup       test_group
+* @{
+*
+* ## Test bme driver
+*

--- a/tests/driver_bme280/main.c
+++ b/tests/driver_bme280/main.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2016 Kees Bakker, SODAQ
+ *               2018 Freie Universität Berlin
+ * Copyright (C) 2022 Mesh4all mesh4all.org
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @ingroup     test_group_driver_bme280
+ * @{
+ *
+ * @file
+ * @brief       Test application for the BME280 temperature, pressure, and
+ *              humidity sensor driver
+ *
+ * @author      Kees Bakker <kees@sodaq.com>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Luis A. Ruiz <luisan00@hotmail.com>
+ * @}
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "bmx280_params.h"
+#include "bmx280.h"
+#include "fmt.h"
+#include "embUnit.h"
+
+bmx280_t bme280;
+
+static const bmx280_params_t default_bme280_params[] = {
+    {.i2c_dev = I2C_DEV(0), .i2c_addr = 0x76, BMX280_PARAM_MISC},
+};
+
+void bme280_init(void) {
+    // It should be initialized
+    int error = bmx280_init(&bme280, &default_bme280_params[0]);
+
+    switch (error) {
+    case BMX280_ERR_BUS:
+        printf("[Error] Something went wrong when using the I2C bus\n");
+        break;
+    case BMX280_ERR_NODEV:
+        printf("[Error] Unable to communicate with the BME280 device\n");
+        break;
+    case BMX280_OK:
+        printf("BME280 - Initialized\n");
+        break;
+    default:
+        printf("[Error] This should never happen\n");
+        break;
+    }
+    TEST_ASSERT_EQUAL_INT(0, error);
+}
+
+void bme280_get_temperature(void) {
+    // It should be able to read temperature
+    int16_t temperature = bmx280_read_temperature(&bme280);
+
+    char str_temperature[8];
+    size_t len = fmt_s16_dfp(str_temperature, temperature, -2);
+    str_temperature[len] = '\0';
+    printf("BME280 - Temperature: %s ºC\n", str_temperature);
+
+    // It should be greater than -32768
+    TEST_ASSERT(temperature > -32768);
+}
+
+void bme280_get_pressure(void) {
+    // It should be able to read pressure in Pascal [Pa]
+    uint32_t pressure = bmx280_read_pressure(&bme280);
+
+    printf("BME280 - Pressure: %" PRIu32 " Pa\n", pressure);
+
+    // It should be less than 4294967295 or 0xFFFFFFFF
+    TEST_ASSERT(pressure < 4294967295);
+}
+
+void bme280_get_humiditty(void) {
+    // It should be able to read humidity
+    uint16_t humidity = bme280_read_humidity(&bme280);
+
+    char str_humidity[8];
+    size_t len = fmt_s16_dfp(str_humidity, humidity, -2);
+    str_humidity[len] = '\0';
+    printf("BME280 - Humidity: %s %%rH\n", str_humidity);
+
+    // It should be greater than zero
+    TEST_ASSERT(humidity > 0);
+}
+
+Test *test_bme280_driver(void) {
+
+    EMB_UNIT_TESTFIXTURES(fixtures){
+        new_TestFixture(bme280_init),
+        new_TestFixture(bme280_get_temperature),
+        new_TestFixture(bme280_get_pressure),
+        new_TestFixture(bme280_get_humiditty),
+    };
+
+    EMB_UNIT_TESTCALLER(test_bme280_driver, NULL, NULL, fixtures);
+
+    return (Test *)&test_bme280_driver;
+}
+
+int main(void) {
+    printf("\n");
+    printf("Test BME280 driver\n");
+
+    TESTS_START();
+    TESTS_RUN(test_bme280_driver());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/driver_bme280/tests/01-run.py
+++ b/tests/driver_bme280/tests/01-run.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run_check_unittests
+
+if __name__ == "__main__":
+    sys.exit(run_check_unittests())

--- a/tests/periph_adc/doc.txt
+++ b/tests/periph_adc/doc.txt
@@ -1,15 +1,36 @@
 /**
-@defgroup      periph_adc
-@ingroup       test_group
+@defgroup      periph_adc   Read values using ADC peripheral
+@ingroup       tests
 @{
 
 ## Test the [A]nalog to [D]igital [C]onverter peripheral
 
-To test the code in automatic mode:
+This test gets the list of ADC pins available and read their values.
 
-```c
-make flash test
+### Compile, flash and test
+
+You can compile and flash by executing:
+
+```sh
+make BOARD=<your_board> flash
 ```
 
+Then open a terminal with:
+
+```sh
+make BOARD=<your_board> term
+```
+
+And start the tests by typing [S]
+
+
+* **Also** you can run the test in **auto mode** with:
+*
+* ```sh
+* make <your_board> flash test
+* ```
+
+@note \<your_board> must be changed by one of @ref boards
+
 @}
- */
+*/

--- a/tests/periph_i2c/Makefile
+++ b/tests/periph_i2c/Makefile
@@ -1,0 +1,11 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_i2c
+FEATURES_OPTIONAL = periph_i2c_reconfigure
+
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
+USEMODULE += i2c_scan
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_i2c/Makefile
+++ b/tests/periph_i2c/Makefile
@@ -1,10 +1,8 @@
 include ../Makefile.tests_common
-
+# Required/Optional features
 FEATURES_REQUIRED = periph_i2c
 FEATURES_OPTIONAL = periph_i2c_reconfigure
-
-USEMODULE += ztimer
-USEMODULE += ztimer_msec
+# Required modules
 USEMODULE += i2c_scan
 USEMODULE += embunit
 

--- a/tests/periph_i2c/app.config.test
+++ b/tests/periph_i2c/app.config.test
@@ -7,9 +7,5 @@ CONFIG_MODULE_PERIPH_I2C=y
 # Enable I2C scan
 CONFIG_MODULE_I2C_SCAN=y
 
-# Enable xtimer to wake up periodically
-CONFIG_MODULE_ZTIMER=y
-CONFIG_MODULE_ZTIMER_MSEC=y
-
 # Enable stuffs related to tests
 CONFIG_MODULE_EMBUNIT=y

--- a/tests/periph_i2c/app.config.test
+++ b/tests/periph_i2c/app.config.test
@@ -1,0 +1,15 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+
+# Enable I2C peripheral driver
+CONFIG_MODULE_PERIPH_I2C=y
+
+# Enable I2C scan 
+CONFIG_MODULE_I2C_SCAN=y
+
+# Enable xtimer to wake up periodically
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y
+
+# Enable stuffs related to tests
+CONFIG_MODULE_EMBUNIT=y

--- a/tests/periph_i2c/app.config.test
+++ b/tests/periph_i2c/app.config.test
@@ -4,7 +4,7 @@
 # Enable I2C peripheral driver
 CONFIG_MODULE_PERIPH_I2C=y
 
-# Enable I2C scan 
+# Enable I2C scan
 CONFIG_MODULE_I2C_SCAN=y
 
 # Enable xtimer to wake up periodically

--- a/tests/periph_i2c/doc.txt
+++ b/tests/periph_i2c/doc.txt
@@ -1,11 +1,14 @@
 /**
-* @defgroup      periph_i2c   Get I2C available devices
-* @ingroup       tests
+* @defgroup      test_group_periph_i2c   Get I2C available ports and scan for devices
+* @ingroup       test_group
 * @{
 *
-* ## Test the I2C peripheral
+* ## Low level test for I2C peripherals
 *
-* This test gets the list of I2C devices available.
+* This test will try:
+*
+* - Return the number of I2C available ports.
+* - Scan for connected devices on the available I2C ports.
 *
 * ### Compile, flash and test
 *
@@ -22,7 +25,6 @@
 * ```
 *
 * And start the tests by typing [S]
-*
 *
 * **Also** you can run the test in **auto mode** with:
 *

--- a/tests/periph_i2c/doc.txt
+++ b/tests/periph_i2c/doc.txt
@@ -1,0 +1,36 @@
+/**
+* @defgroup      periph_i2c   Get I2C available devices
+* @ingroup       tests
+* @{
+*
+* ## Test the I2C peripheral
+*
+* This test gets the list of I2C devices available.
+*
+* ### Compile, flash and test
+*
+* You can compile and flash by executing:
+*
+* ```sh
+* make BOARD=<your_board> flash
+* ```
+*
+* Then open a terminal with:
+*
+* ```sh
+* make BOARD=<your_board> term
+* ```
+*
+* And start the tests by typing [S]
+*
+*
+* **Also** you can run the test in **auto mode** with:
+*
+* ```sh
+* make <your_board> flash test
+* ```
+*
+* @note \<your_board> must be changed by one of @ref boards
+*
+* @}
+*/

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -15,9 +15,13 @@
  */
 
 /**
+ * @ingroup     test_group_periph_i2c
+ * @{
+ * @file
  * @brief       I2C low level test
  *
  * @author      Luis A. Ruiz <luisan00@hotmail.com>
+ * @}
  */
 #include <string.h>
 #include <stdio.h>
@@ -28,7 +32,6 @@
 #include "periph/gpio.h"
 #include "periph/i2c.h"
 
-#include "ztimer.h"
 #include "embUnit.h"
 
 uint16_t i2c_scan_dev(i2c_t dev) {

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 Mesh4all mesh4all.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @brief       ADC test
+ *
+ * @author      Luis A. Ruiz <luisan00@hotmail.com>
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "periph_conf.h"
+#include "periph/gpio.h"
+#include "periph/i2c.h"
+
+#include "ztimer.h"
+#include "embUnit.h"
+
+void get_i2c_numof(void) {
+    int i2c_available = I2C_NUMOF;
+    printf("Number of available i2c devices for the %s board is %d\n", RIOT_BOARD, i2c_available);
+    TEST_ASSERT_NOT_NULL(&i2c_available);
+}
+
+void acquiring_devices(void) {
+    int err = 0;
+    printf("Trying to acquire I2C available devices\n");
+
+    for (int addr = 0; addr < 255; addr++) {
+    }
+}
+
+Test *test_periph_i2c(void) {
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(get_i2c_numof), // return available devices for the current board.
+        #if (I2C_NUMOF > 0)
+        new_TestFixture(acquiring_devices), // scan for conected devices.
+        #endif
+    };
+
+    EMB_UNIT_TESTCALLER(test_periph_i2c, NULL, NULL, fixtures);
+
+    return (Test *)&test_periph_i2c;
+}
+
+int main(void) {
+    printf("Test I2C peripherals\n");
+    TESTS_START();
+    TESTS_RUN(test_periph_i2c());
+    TESTS_END();
+    return 0;
+}

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -15,7 +15,7 @@
  */
 
 /**
- * @brief       ADC test
+ * @brief       I2C low level test
  *
  * @author      Luis A. Ruiz <luisan00@hotmail.com>
  */
@@ -31,26 +31,62 @@
 #include "ztimer.h"
 #include "embUnit.h"
 
-void get_i2c_numof(void) {
-    int i2c_available = I2C_NUMOF;
-    printf("Number of available i2c devices for the %s board is %d\n", RIOT_BOARD, i2c_available);
-    TEST_ASSERT_NOT_NULL(&i2c_available);
+uint16_t i2c_scan_dev(i2c_t dev) {
+    i2c_acquire(dev);
+    uint16_t ack_addr = 0;
+    for (char i = 0; i < 8; i++) {
+        uint16_t addr = i;
+        addr <<= 4;
+        for (unsigned j = 0; j < 16; j++) {
+
+            char dummy[1];
+            int retval;
+            while (-EAGAIN == (retval = i2c_read_byte(dev, addr, dummy, 0))) {
+            }
+            switch (retval) {
+            case 0:
+                ack_addr = addr;
+                break;
+            case -ENXIO:
+                break;
+            default:
+                printf("I2C_DEV(%d) - Error: 0x%x\n", dev, addr);
+                break;
+            }
+            addr++;
+        }
+    }
+    i2c_release(dev);
+    return ack_addr;
 }
 
-void acquiring_devices(void) {
-    int err = 0;
-    printf("Trying to acquire I2C available devices\n");
+void get_i2c_numof(void) {
+    printf("Number of available i2c ports in the %s board: %d\n", RIOT_BOARD, I2C_NUMOF);
+    TEST_ASSERT(I2C_NUMOF > 0);
+}
 
-    for (int addr = 0; addr < 255; addr++) {
+void scan_devices(void) {
+
+    int dev_found = 0;
+
+    for (size_t idx = 0; idx < I2C_NUMOF; idx++) {
+        uint16_t addr = i2c_scan_dev(I2C_DEV(idx));
+        printf("I2C_DEV(%d) Found: 0x%x\n", (int)idx, addr);
+        if (addr) {
+            dev_found = 1;
+        }
     }
+    if (!dev_found) {
+        printf("No devices\n");
+    }
+
+    TEST_ASSERT_EQUAL_INT(1, dev_found);
 }
 
 Test *test_periph_i2c(void) {
-    EMB_UNIT_TESTFIXTURES(fixtures) {
-        new_TestFixture(get_i2c_numof), // return available devices for the current board.
-        #if (I2C_NUMOF > 0)
-        new_TestFixture(acquiring_devices), // scan for conected devices.
-        #endif
+    EMB_UNIT_TESTFIXTURES(fixtures){
+        new_TestFixture(get_i2c_numof), // Return available i2c ports for the current board.
+        new_TestFixture(scan_devices),  // Scan for connected devices on the available ports.
     };
 
     EMB_UNIT_TESTCALLER(test_periph_i2c, NULL, NULL, fixtures);

--- a/tests/periph_i2c/tests/01-run.py
+++ b/tests/periph_i2c/tests/01-run.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run_check_unittests
+
+if __name__ == "__main__":
+    sys.exit(run_check_unittests())


### PR DESCRIPTION
### Contribution description
This PR add initial support for **I2C** and **SPI** peripherals for **Meshme** board

### Testing procedure
Build and flashing procedures for **Meshme** board should works as expected with the new changes but also with two new test:
- `tests/periph_i2c`   
- `tests/driver_bme280`

This pull request could open a new issue: 
- A low level test for **SPI** peripherals should be added

### Issues/PRs references
Not now but it should be added in the short term