### PR TITLE
sys/uniqueid: Fixed compilation dependencies of HWRNG and radio hardware

### DIFF
--- a/firmware/sys/uniqueid/Kconfig
+++ b/firmware/sys/uniqueid/Kconfig
@@ -20,8 +20,10 @@ menu "Subnet"
         config MODE_STATIC
             bool "STATIC"
 
+        if USEMODULE_AT86RF2XX || USEMODULE_AT86RF215 || USEMODULE_PERIPH_HWRNG
         config MODE_RANDOM
             bool "RANDOM"
+        endif
 
         config MODE_MANUAL
             bool "MANUAL"

--- a/firmware/sys/uniqueid/Makefile.dep
+++ b/firmware/sys/uniqueid/Makefile.dep
@@ -4,8 +4,10 @@ USEMODULE += netdev_default
 USEMODULE += gnrc_ipv6_default
 USEMODULE += auto_init_gnrc_netif
 
-ifneq (,$(filter m4a-24g m4a-mb,$(BOARD)))
+ifneq (,$(filter at86rf2xx at86rf215,$(USEMODULE)))
     USEMODULE += radio
 else
-    USEMODULE += periph_hwrng
+    ifneq (,$(filter periph_hwrng,$(HAS_PERIPH_HWRNG)))
+        USEMODULE += periph_hwrng
+    endif
 endif

--- a/firmware/sys/uniqueid/uniqueid.c
+++ b/firmware/sys/uniqueid/uniqueid.c
@@ -29,7 +29,7 @@
 #include "net/gnrc.h"
 #if MODULE_AT86RF2XX || MODULE_AT86RF215
 #include "radio.h"
-#else
+#elif MODULE_PERIPH_HWRNG
 #include "periph/hwrng.h"
 #endif
 void subnet_to_ipv6(ipv6_addr_t *addr) {

--- a/tests/uniqueid/main.c
+++ b/tests/uniqueid/main.c
@@ -42,18 +42,23 @@ void get_unique_from_mac(ipv6_addr_t *output) {
 }
 
 void test_get_ipv6Address(void) {
+#if CONFIG_MODE_STATIC || CONFIG_MODE_MANUAL
     ipv6_addr_t ipv6 = {
         .u8 = {0},
     };
-
-    subnet_to_ipv6(&ipv6);
-#ifdef CONFIG_MODE_STATIC
     ipv6_addr_t output = {
         .u8 = {0},
     };
+    printf("\n");
+    subnet_to_ipv6(&ipv6);
     ipv6_addr_print(&ipv6);
+    printf("\n");
     get_unique_from_mac(&output);
+#if CONFIG_MODE_STATIC
     TEST_ASSERT_EQUAL_INT(1, ipv6_addr_equal(&ipv6, &output));
+#elif CONFIG_MODE_MANUAL
+    TEST_ASSERT_EQUAL_INT(1, !ipv6_addr_equal(&ipv6, &output));
+#endif
 #endif
 
 #ifdef CONFIG_MODE_RANDOM
@@ -63,7 +68,6 @@ void test_get_ipv6Address(void) {
     ipv6_addr_t output2 = {
         .u8 = {0},
     };
-
     subnet_to_ipv6(&output1);
     subnet_to_ipv6(&output2);
     printf("\nFirst random IPv6\n");


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
The uniqueid was presenting a compilation errors in others boards. so to fix this was added an dependency conditionals that check and verify if the device has or not the required hardware. Another important feature added is the condition that is not has the required hardware only could be work with two mode (`STATIC` and `MANUAL`). 
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
```
make BOARD=cc1352p-launchpad menuconfig
```
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fixes #319 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
