### PR TITLE
test/storage: Support to cc2538 with `mtd_save_compress` and `mtd_load`

### DIFF
--- a/firmware/sys/storage/include/storage.h
+++ b/firmware/sys/storage/include/storage.h
@@ -35,6 +35,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 #define LAST_AVAILABLE_PAGE (FLASHPAGE_NUMOF - 1) /*!< Last position in the block EEPROM*/
 #define MAX_SIZE_STORAGE (FLASHPAGE_SIZE)           /*!< max size to save in the page */
 #define MAX_NUMOF_FLASHPAGES FLASHPAGE_NUMOF      /*!< max num of pages that can be manipulated */


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
This new PR implements a new model to run the storage module, I recommend let this module in constantly review, because is throwing a cppcheck static test alert, that was suppressed. Well the new model to use `mtd_save_compress` and `mtd_load()` is working, but the old functions of storage, are freezing the terminal when it's running the test. So this new PR are providing support to cc2538 boards (`meshme`, `vs203`), the m4a-24g and the m4a-mb board.
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
Start running the storage test:
```
make -C test/storage BOARD=meshme flash term
```
### Expected Output:

In meshme board
```
..
Saving data:
numpages : 1
.

Loading data:

varui8_attr1 [1]: 2
varui8_attr1 [2]: 5
varui8_attr1 [3]: 6
varui8_attr1 [4]: 7
varui8_attr1 [5]: 8
varui8_attr1 [6]: 9

varui32_attr2 [1]: 1555
varui32_attr2 [2]: 2556
varui32_attr2 [3]: 477
varui32_attr2 [4]: 8975
varui32_attr2 [5]: 987
varui32_attr2 [6]: 414

varstr_attr3: Welcome to mesh storage!!!

vari32_attr4 [1]: 1550
vari32_attr4 [2]: 5544
vari32_attr4 [3]: -698
vari32_attr4 [4]: -789
vari32_attr4 [5]: -97852
vari32_attr4 [6]: 0
vari32_attr4 [7]: 0
vari32_attr4 [8]: 0
vari32_attr4 [9]: 0
vari32_attr4 [10]: 0
vari32_attr4 [11]: 0
vari32_attr4 [12]: 0
vari32_attr4 [13]: 0
vari32_attr4 [14]: 0
vari32_attr4 [15]: 0
vari32_attr4 [16]: 0
vari32_attr4 [17]: 0
vari32_attr4 [18]: 0
vari32_attr4 [19]: 0
vari32_attr4 [20]: 0
vari32_attr4 [21]: 0
vari32_attr4 [22]: 0
vari32_attr4 [23]: 0
vari32_attr4 [24]: 0
vari32_attr4 [25]: 0
vari32_attr4 [26]: 0
vari32_attr4 [27]: 0
vari32_attr4 [28]: 0
vari32_attr4 [29]: 0
vari32_attr4 [30]: 0
vari32_attr4 [31]: 0
vari32_attr4 [32]: 0
vari32_attr4 [33]: 0
vari32_attr4 [34]: 0
vari32_attr4 [35]: 0
vari32_attr4 [36]: 0
vari32_attr4 [37]: 0
vari32_attr4 [38]: 0
vari32_attr4 [39]: 0
vari32_attr4 [40]: 0
vari32_attr4 [41]: 0
vari32_attr4 [42]: 0
vari32_attr4 [43]: 0
vari32_attr4 [44]: 0
vari32_attr4 [45]: 0
vari32_attr4 [46]: 0
vari32_attr4 [47]: 0
vari32_attr4 [48]: 0
vari32_attr4 [49]: 0
vari32_attr4 [50]: 2556

.numpages : 1
.

Loading Firmware default data:

Tx_power:  -30
Sub_GHz:  YES
Channel: 11

Routing

Rpl_mode: DAG
RPL instance: 0
pan_id: 0x20
Wifi-subsys: NO
Amount of sensors 2

Sensor Id 1 
Class of Sensor: MOISTURE SENSOR
Application Type of Sensor: SOIL SENSOR
Input pin: 5

Sensor Id 2 
Class of Sensor: TEMPERATURE SENSOR
Application Type of Sensor: AIR SENSOR
Input pin: 1

OK (5 tests)

```
This result was obtained from [IOT-LAB experiment#326423](https://www.iot-lab.info/testbed/experiments/326423)
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fixes #314 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
