### PR TITLE
firmware/radio: Compillation Fixed to unregister netdev devices

### DIFF
--- a/firmware/network/radio/radio.c
+++ b/firmware/network/radio/radio.c
@@ -39,10 +39,10 @@ int8_t subtract_to_interface = 0;
 #endif
 
 bool identify_multiple_radio_interface(void) {
-    int8_t index = get_ieee802154_iface() + subtract_to_interface;
-    gnrc_netif_t *iface_mult = gnrc_netif_get_by_pid(index);
+    int8_t index = get_ieee802154_iface();
+    gnrc_netif_t *iface_mult = gnrc_netif_get_by_pid(index + 1);
     if (index != -1) {
-        if (gnrc_netif_get_by_type(iface_mult->dev->type, index - 1) != NULL) {
+        if (iface_mult != NULL) {
             return true;
         }
     }
@@ -52,7 +52,7 @@ bool identify_multiple_radio_interface(void) {
 int8_t get_ieee802154_iface(void) {
     int max_ifaces = gnrc_netif_numof();
     if (max_ifaces > 0) {
-        gnrc_netif_t *iface;
+        gnrc_netif_t *iface = NULL;
         for (uint8_t i = 0; i < ARRAY_SIZE(radio_devices); i++) {
             iface = gnrc_netif_get_by_type(radio_devices[i], NETDEV_INDEX_ANY);
             if (iface != NULL) {
@@ -65,12 +65,17 @@ int8_t get_ieee802154_iface(void) {
             return -1;
         }
     }
+    printf("Error: Radio interface doesn't exist, File:%s line:%d function: %s\n", __FILE__,
+           __LINE__, __func__);
     return -1;
 }
 
 int8_t get_netopt_tx_power(int16_t txpower) {
     int res;
     int index = get_ieee802154_iface();
+    if (index < 0) {
+        return -1;
+    }
     netif_t *iface = netif_get_by_id(index);
 
     res = netif_get_opt(iface, NETOPT_TX_POWER, 0, &txpower, sizeof(txpower));
@@ -86,6 +91,9 @@ int8_t get_netopt_tx_power(int16_t txpower) {
 int8_t get_netopt_channel(int16_t channel) {
     int res;
     int index = get_ieee802154_iface();
+    if (index < 0) {
+        return -1;
+    }
     netif_t *iface = netif_get_by_id(index);
 
     res = netif_get_opt(iface, NETOPT_CHANNEL, 0, &channel, sizeof(channel));
@@ -101,6 +109,9 @@ int8_t get_netopt_channel(int16_t channel) {
 int8_t set_netopt_tx_power(int16_t txpower) {
     int res;
     int index = get_ieee802154_iface();
+    if (index < 0) {
+        return -1;
+    }
     netif_t *iface = netif_get_by_id(index);
     if (txpower < TX_POWER_MIN || txpower > TX_POWER_MAX) {
         printf("Error: the txPower must be between %d dbm and %d dbm \n", TX_POWER_MIN,
@@ -121,6 +132,9 @@ int8_t set_netopt_tx_power(int16_t txpower) {
 int8_t set_netopt_channel(int16_t channel) {
     int res;
     int index = get_ieee802154_iface();
+    if (index < 0) {
+        return -1;
+    }
     netif_t *iface = netif_get_by_id(index);
 #ifdef CONFIG_MODE_SUB_24GHZ
     if (channel < 0 || channel > 10) {


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
This contribution adds support to unregistered network devices, example if the netdev interface doesn't exist, All the operations of the module, should be stopped.
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
The test with `cc1312-launchpad` board.

step to provide the uniflash programmer (also could be used openocd as programmer)
```
export PROGRAMMER=uniflash
```
then, run the test radio.
```
make -C tests/radio flash term BOARD=cc1312-launchpad
```

### Expected results
Well, if the device doesn't have a radio interface, the all ran tests should been failed.
```
2022-07-25 17:36:57,965 # radio_tests.test_get_netopt_channel (/home/eduardo-az/github-forks/m4a-firmware/tests/radio/main.c 40) exp 0 was -1
2022-07-25 17:36:57,979 # .Error: Radio interface doesn't exist, File:/home/eduardo-az/github-forks/m4a-firmware/firmware/network/radio/radio.c line:69 function: get_ieee802154_iface
2022-07-25 17:36:57,992 # Error: Radio interface doesn't exist, File:/home/eduardo-az/github-forks/m4a-firmware/firmware/network/radio/radio.c line:69 function: get_ieee802154_iface
2022-07-25 17:36:57,995 # Error: Failed to add TX_power.
2022-07-25 17:36:57,995 # 
2022-07-25 17:36:58,005 # radio_tests.test_initial_radio_setup (/home/eduardo-az/github-forks/m4a-firmware/tests/radio/main.c 45) exp 0 was -1
2022-07-25 17:36:58,005 # 
2022-07-25 17:36:58,007 # run 4 failures 4
```
This resolved a support to compile in the no-radio devices
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fixes #324
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
