### PR TITLE
riotboot: fixed Kernel panics

### DIFF
--- a/tests/riotboot/main.c
+++ b/tests/riotboot/main.c
@@ -27,8 +27,7 @@
 #include "riotboot/slot.h"
 #include "shell.h"
 
-static int cmd_show_slot_nr(int argc, char **argv)
-{
+static int cmd_show_slot_nr(int argc, char **argv) {
     (void)argc;
     (void)argv;
 
@@ -36,8 +35,7 @@ static int cmd_show_slot_nr(int argc, char **argv)
     return 0;
 }
 
-static int cmd_show_slot_hdr(int argc, char **argv)
-{
+static int cmd_show_slot_hdr(int argc, char **argv) {
     (void)argc;
     (void)argv;
 
@@ -46,18 +44,20 @@ static int cmd_show_slot_hdr(int argc, char **argv)
     return 0;
 }
 
-static int cmd_show_slot_addr(int argc, char **argv)
-{
+static int cmd_show_slot_addr(int argc, char **argv) {
     (void)argc;
 
-    int reqslot=atoi(argv[1]);
-    printf("Slot %d address=0x%08" PRIx32 "\n",
-           reqslot, riotboot_slot_get_image_startaddr(reqslot));
+    uint8_t reqslot = atoi(argv[1]);
+    if (reqslot >= riotboot_slot_numof) {
+        printf("The slot doesn't exist.\n");
+        return -1;
+    }
+    printf("Slot %d address=0x%08" PRIx32 "\n", reqslot,
+           riotboot_slot_get_image_startaddr(reqslot));
     return 0;
 }
 
-static int cmd_dumpaddrs(int argc, char **argv)
-{
+static int cmd_dumpaddrs(int argc, char **argv) {
     (void)argc;
     (void)argv;
 
@@ -66,15 +66,13 @@ static int cmd_dumpaddrs(int argc, char **argv)
 }
 
 static const shell_command_t shell_commands[] = {
-    { "showslot", "Print current slot number", cmd_show_slot_nr },
-    { "showhdr", "Print current slot header", cmd_show_slot_hdr },
-    { "showslotaddr", "Print address of requested slot", cmd_show_slot_addr },
-    { "dumpaddrs", "Prints all slot data in header", cmd_dumpaddrs },
-    { NULL, NULL, NULL }
-};
+    {"showslot", "Print current slot number", cmd_show_slot_nr},
+    {"showhdr", "Print current slot header", cmd_show_slot_hdr},
+    {"showslotaddr", "Print address of requested slot", cmd_show_slot_addr},
+    {"dumpaddrs", "Prints all slot data in header", cmd_dumpaddrs},
+    {NULL, NULL, NULL}};
 
-int main(void)
-{
+int main(void) {
     int current_slot;
 
     puts("Hello Mesh-boot!");
@@ -87,8 +85,7 @@ int main(void)
     if (current_slot != -1) {
         printf("riotboot_test: running from slot %d\n", current_slot);
         riotboot_slot_print_hdr(current_slot);
-    }
-    else {
+    } else {
         printf("[FAILED] You're not running riotboot\n");
     }
 


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
In the current test the `showslotaddr` command only could check the slot 0 and 1, but if the input slot doesn´t exist, the device will throw an assertion of kernel panic. To fix this, the global variable riotboot_slot_numof in the RIOT submodule file ( `riotboot/slot.c` ) .
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
first build the riotboot
```
make all
```
then flash using the riotboot makefile rule.
```
make riotboot/flash
```
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fixes #333 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
