### PR TITLE
riotboot: Riotboot features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,6 @@ endif
 
 #Bootloaders params
 
-ifneq (,$(filter meshme vs203,$(BOARD)))	# Unsupported board without periph/usbdev (DFU not supported)
-	BOOTLOADER_DIR := RIOT/bootloaders/riotboot
-else
-	BOOTLOADER_DIR := RIOT/bootloaders/riotboot_dfu
-endif
-
 all:
 	- $(MAKE_CMD) -C firmware
 
@@ -30,21 +24,10 @@ clean:
 menuconfig:
 	- $(MAKE_CMD) -C firmware menuconfig
 
-install-boot:
-	- $(MAKE_CMD) EXTERNAL_BOARD_DIRS=$(CURDIR)/boards -C $(BOOTLOADER_DIR) flash
-	@echo Please connect in the DFU mode. Change to the port Target and them run:
-	@echo + make update
-
-ifneq (,$(filter meshme vs203,$(BOARD)))
-update:
-	- FEATURES_REQUIRED=riotboot $(MAKE_CMD) M4ABOOT=1 -C firmware all riotboot/flash-slot0
-else
-update:
-	- FEATURES_REQUIRED=riotboot USEMODULE=usbus_dfu $(MAKE_CMD) M4ABOOT=1 -C firmware all riotboot/flash-slot0
-endif
-
 docs:
 	cd doc/doxygen && make
 
+-include makefiles/tools/bootloader.mk
+-include makefiles/tools/firmupdater.mk
 -include makefiles/tools/m4agen.inc.mk
 -include makefiles/tests.inc.mk

--- a/examples/Makefile.common
+++ b/examples/Makefile.common
@@ -1,5 +1,11 @@
+APPBASE ?= $(CURDIR)
 BOARD ?= m4a-24g
 QUIET ?= 1
 RIOTBASE ?= $(CURDIR)/../../RIOT
+MESHBASE ?= $(RIOTBASE)/..
 EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../boards
 EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/peripherals
+EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/network
+EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/sys
+
+-include $(MESHBASE)/makefiles/tools/firmupdater.mk

--- a/examples/blinking/Makefile
+++ b/examples/blinking/Makefile
@@ -1,4 +1,4 @@
-APPLICATION = external_led
+APPLICATION = blinking
 
 include ../Makefile.common
 

--- a/examples/mesh4all_rpl_dag/Makefile
+++ b/examples/mesh4all_rpl_dag/Makefile
@@ -1,21 +1,8 @@
 APPLICATION = mesh4all-rpl
-BOARD ?= m4a-24g
-
-# Current path
-APPBASE ?= $(CURDIR)
-
-# RIOT-OS's base path
-RIOTBASE ?= $(CURDIR)/../../RIOT
-
-# Custom boards "MUST BE" into "boards" folder, it's code **strongly** hardware dependent
-EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../boards
-
-# If We need custom actions, routines, etc **SHOULD BE** included in the "core" folder
-# 	and "MUST BE" code hardware independent
-# EXTERNAL_MODULE_DIRS += $(CURDIR)/../core
 
 DEVHELP ?= 1
-QUIET ?= 1
+
+include ../Makefile.common
 
 # Modules
 USEMODULE += saul_default
@@ -28,14 +15,8 @@ USEMODULE += ps
 #	target board
 
 USEMODULE += rpl_protocol
-USEMODULE += radio
 USEMODULE += gnrc_icmpv6_echo
 
-EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/peripherals
-EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/network
-EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/sys
-
 # Use UART_DEV(1) for slipdev as a default, baudrate by default is 115200
-
 
 include $(RIOTBASE)/Makefile.include

--- a/examples/mesh4all_rpl_dodag/Makefile
+++ b/examples/mesh4all_rpl_dodag/Makefile
@@ -1,42 +1,22 @@
-APPLICATION = mesh4all-rpl
-BOARD ?= m4a-24g
-
-# Current path
-APPBASE ?= $(CURDIR)
-
-# RIOT-OS's base path
-RIOTBASE ?= $(CURDIR)/../../RIOT
-
-# Custom boards "MUST BE" into "boards" folder, it's code **strongly** hardware dependent
-EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../boards
+APPLICATION = mesh4all-rpl-dodag
 
 # If We need custom actions, routines, etc **SHOULD BE** included in the "core" folder
 # 	and "MUST BE" code hardware independent
 # EXTERNAL_MODULE_DIRS += $(CURDIR)/../core
 
 DEVHELP ?= 1
-QUIET ?= 1
 
+include ../Makefile.common
 # Modules
 USEMODULE += saul_default
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-# Custom modules
-# Note: this code is hardware independent but "COULD BE" configurable for a
-#	target board
-
 USEMODULE += rpl_protocol
 USEMODULE += radio
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += at_client
-
-EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/peripherals
-EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/network
-EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/sys
-
-# Use UART_DEV(1) for slipdev as a default, baudrate by default is 115200
 
 
 include $(RIOTBASE)/Makefile.include

--- a/examples/system_example/Makefile
+++ b/examples/system_example/Makefile
@@ -1,21 +1,9 @@
 APPLICATION = system-mesh
 BOARD ?= m4a-24g
 
-# Current path
-APPBASE ?= $(CURDIR)
-
-# RIOT-OS's base path
-RIOTBASE ?= $(CURDIR)/../../RIOT
-
-# Custom boards "MUST BE" into "boards" folder, it's code **strongly** hardware dependent
-EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../boards
-
-# If We need custom actions, routines, etc **SHOULD BE** included in the "core" folder
-# 	and "MUST BE" code hardware independent
-# EXTERNAL_MODULE_DIRS += $(CURDIR)/../core
+include ../Makefile.common
 
 DEVHELP ?= 1
-QUIET ?= 1
 
 # Modules
 USEMODULE += saul_default
@@ -37,11 +25,6 @@ USEMODULE += udp_client
 USEMODULE += udp_server
 USEMODULE += at_client
 
-EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/peripherals
-EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/network
-EXTERNAL_MODULE_DIRS += $(CURDIR)/../../firmware/sys
-
 # Use UART_DEV(1) for slipdev as a default, baudrate by default is 115200
-
 
 include $(RIOTBASE)/Makefile.include

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -45,4 +45,5 @@ CFLAGS += "-DSLIPDEV_PARAM_UART=UART_DEV($(SLIP_UART))"
 # LOG_ALL;     print everything
 CFLAGS += -DLOG_LEVEL=LOG_ALL
 
-include $(RIOTBASE)/Makefile.include
+-include ../makefiles/tools/firmupdater.mk
+-include $(RIOTBASE)/Makefile.include

--- a/makefiles/tools/bootloader.mk
+++ b/makefiles/tools/bootloader.mk
@@ -1,0 +1,14 @@
+ifndef RIOTBASE
+RIOTBASE ?= RIOT
+endif
+
+ifneq (,$(filter meshme vs203,$(BOARD)))	# Unsupported board without periph/usbdev (DFU not supported)
+	BOOTLOADER_DIR ?= $(RIOTBASE)/bootloaders/riotboot
+else
+	BOOTLOADER_DIR ?= $(RIOTBASE)/bootloaders/riotboot_dfu
+endif
+
+install-bootloader:
+	make -C ${BOOTLOADER_DIR} flash
+	@echo Please connect in the DFU mode. Change to the port Target and them run:
+	@echo + make upload

--- a/makefiles/tools/firmupdater.mk
+++ b/makefiles/tools/firmupdater.mk
@@ -1,0 +1,11 @@
+ifndef APPBASE
+APPBASE := $(RIOTBASE)/../firmware	#This refers to called m4a-firmware
+endif
+
+ifneq (,$(filter meshme vs203,$(BOARD)))
+upload:
+	- FEATURES_REQUIRED=riotboot $(MAKE_CMD) M4ABOOT=1 -C $(APPBASE) all riotboot/flash-slot0
+else
+upload:
+	- FEATURES_REQUIRED=riotboot USEMODULE=usbus_dfu make M4ABOOT=1 -C $(APPBASE) all riotboot/flash-slot0
+endif

--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -14,7 +14,9 @@ ifneq (,$(filter tests_driver_%,$(APPLICATION)))
   BOARD ?= m4a-24g
 endif
 
+APPBASE ?= $(CURDIR)
 BOARD ?= m4a-24g
+MESHBASE ?= $(RIOTBASE)/..
 QUIET ?= 1
 RIOTBASE ?= $(CURDIR)/../../RIOT
 EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../boards
@@ -29,3 +31,5 @@ CFLAGS += "-DSLIPDEV_PARAM_UART=UART_DEV($(SLIP_UART))"
 
 # DEVELHELP enabled by default for all tests, set 0 to disable
 DEVELHELP ?= 1
+
+-include $(MESHBASE)/makefiles/tools/firmupdater.mk

--- a/tests/riotboot_dfu/Makefile
+++ b/tests/riotboot_dfu/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+test-boot:
+	make -C $(RIOTBASE)/../ install-boot BOARD=$(BOARD) EXTERNAL_BOARD_DIRS=$(RIOTBASE)/../boards
+	make -C $(RIOTBASE)/../examples/blinking update BOARD=$(BOARD)

--- a/tests/riotboot_dfu/README.md
+++ b/tests/riotboot_dfu/README.md
@@ -1,0 +1,21 @@
+Riotboot_dfu
+============
+
+To test the riotboot dfu you need to connect both usb ports (EDBG and Target) on a samr21-xpro
+board. It's necessary because the bootloader installation and the upload firmware are two
+process made it in different ports.
+
+When you install the bootloader you will get advantage to upload any firmware, exampler or test
+application, using the `make update` rule. So, you could define a `BOARD` if you want to test
+in another usb dfu supported boards.
+
+Usage
+=====
+Run the auto run test, you will install the `riotboot_dfu` bootloader and then you
+will auto upload the `examples/blinking/` application. The expected results is
+load the correctly firmware or application and auto run it after upload it.
+
+Only you need to execute the following make rule.
+```
+make -C tests/riotboot_dfu test-boot
+```

--- a/tests/riotboot_dfu/main.c
+++ b/tests/riotboot_dfu/main.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Mesh4all.org <mesh4all.org>
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       riotboot_dfu bootloader via usb
+ *
+ * @author      eduazocar <eduardoazocar7@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "xtimer.h"
+#include "periph/gpio.h"
+int main(void)
+{
+    puts("Generated Mesh4all application: 'riotboot_dfu'");
+    return 0;
+}

--- a/tests/riotboot_dfu/tests/01-run.py
+++ b/tests/riotboot_dfu/tests/01-run.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2022 Mesh4all.org <mesh4all.org>
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    # put here the pexpect code that checks the output of the test application.
+    pass
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
this propose the riotboot works in each app directory, (examples, tests and firmware). The new feature is that any app actually could be updated via riotboot or `dfu` . Something else that was added is the resetting of device after to build and flash (via bootloader) the firmware or source code.



<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure


<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->
FIrst you need to add the bootloader in your m4a-24g board
```
make install-boot
```
This will build and flash in the board a bootloader to manage two flash slots. (Always manipulate the slot_0)

Then, you could try upload and sample or test application using the bootloader updater.
```
make -C examples/blinking update
```
### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
