### PR TITLE
firmware: confs. for a better performance of RPL routing protocol.

### DIFF
--- a/firmware/network/rpl_protocol/Makefile
+++ b/firmware/network/rpl_protocol/Makefile
@@ -1,5 +1,20 @@
-CFLAGS += -DGNRC_RPL_LIFETIME_UNIT=1 -DGNRC_RPL_DEFAULT_LIFETIME=32
+CFLAGS += -DGNRC_RPL_LIFETIME_UNIT=1
+CFLAGS += -DGNRC_RPL_DEFAULT_LIFETIME=32
 CFLAGS += -DGNRC_RPL_REGULAR_DAO_INTERVAL=13
 CFLAGS += -DGNRC_RPL_DEFAULT_DIO_INTERVAL_DOUBLINGS=13
+
+# Currently only supports storing mode. That means, in order to have downwards routes
+# to all nodes the storage space within gnrc_ipv6's Neighbor Information Base must be
+# big enough to store information for each node.
+#
+# For a random topology of n nodes, to ensure you can reach every node from the root,
+# set CONFIG_GNRC_IPV6_NIB_NUMOF == CONFIG_GNRC_IPV6_NIB_OFFL_NUMOF == n.
+# Ref: https://doc.riot-os.org/group__net__gnrc__rpl.html
+CFLAGS += -DCONFIG_GNRC_IPV6_NIB_NUMOF=50
+CFLAGS += -DCONFIG_GNRC_IPV6_NIB_OFFL_NUMOF=50
+
+# Allow alternative parents, increase num of default routers in the NIB.
+# Ref: https://doc.riot-os.org/group__net__gnrc__rpl.html
+CFLAGS += -DCONFIG_GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF=2
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description
A few `C` flags allow alternative parents and add space for increasing the number of nodes network nodes.

### Testing procedure

Number of alternative parents, is set to 2, so the minimum setup needs at least  3 nodes:
- 2 as DODAG, build and flash `mesh4all_rpl_dodag`
- 1 as DAG, build and flash `mesh4all_rpl_dag`

Turn on all nodes and make sure the two **DODAG** nodes are using different IPV6 addresses.
Open a terminal on the **DAG** node and verify that it can use alternative parents.

Using `zep` create a network at least of 50 nodes acting as DAG and only one as dodag, turn all nodes on.
The DODAG node should show you 50 entries, it correspond to 50 DAG nodes in the network

### Issues/PRs references
None