### PR TITLE
examples: border router added support to foren6

### DIFF
--- a/examples/border_router/Makefile
+++ b/examples/border_router/Makefile
@@ -23,23 +23,28 @@ DEVELHELP ?= 1
 QUIET ?= 1
 
 HOST_IPV6 ?= 2001:db8::1
-IFTYPE ?= USB
+IFTYPE ?= ETHOS
 
 CHAMOC_DIR ?= ../../dist/tools/chamoc
 ETHOS_TOOL ?= $(RIOTBASE)/dist/tools/ethos
+ETHOS_BAUDRATE ?= 115200
 
-ifeq (${IFTYPE},ETHOS)
-	TAP := tap0
-	USEMODULE += stdio_ethos
-	ETHOS_BAUDRATE ?= 115200
-	FEATURES_REQUIRED += periph_uart
-	CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
-	TERMPROG ?= $(ETHOS_TOOL)/ethos
-	TERMFLAGS ?= ${TAP} ${PORT} ${ETHOS_BAUDRATE}
-else ifeq (USB,${IFTYPE})
-	USEMODULE += stdio_cdc_acm
-	USEMODULE += usbus_cdc_ecm
-	USEMODULE += auto_init_usbus
+ifneq (,$(filter native,$(BOARD)))
+	ZEP_DEVICES ?= 1
+	include $(CURDIR)/Makefile.native.conf
+else
+	ifeq (${IFTYPE},ETHOS)
+		TAP ?= tap0
+		USEMODULE += stdio_ethos
+		FEATURES_REQUIRED += periph_uart
+		CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
+		TERMPROG ?= $(ETHOS_TOOL)/ethos
+		TERMFLAGS ?= ${TAP} ${PORT} ${ETHOS_BAUDRATE}
+	else ifeq (USB,${IFTYPE})
+		USEMODULE += stdio_cdc_acm
+		USEMODULE += usbus_cdc_ecm
+		USEMODULE += auto_init_usbus
+	endif
 endif
 
 install:

--- a/examples/border_router/Makefile.native.conf
+++ b/examples/border_router/Makefile.native.conf
@@ -1,0 +1,30 @@
+# native has a TAP interface towards the host, just add parameters for
+# `socket_zep`
+ZEP_PORT_BASE ?= 17754
+ZEP_PORT_MAX := $(shell expr $(ZEP_PORT_BASE) + $(ZEP_DEVICES) - 1)
+
+USEMODULE += netdev_tap
+USEMODULE += socket_zep
+USEMODULE += socket_zep_hello
+
+RIOTTOOLS ?= $(RIOTBASE)/dist/tools/
+
+CFLAGS += -DSOCKET_ZEP_MAX=$(ZEP_DEVICES)
+CFLAGS += -DASYNC_READ_NUMOF=$(shell expr $(ZEP_DEVICES) + 1)
+
+# Set CFLAGS if not being set via Kconfig
+CFLAGS += $(if $(CONFIG_KCONFIG_MODULE_DHCPV6),,-DCONFIG_DHCPV6_CLIENT_PFX_LEASE_MAX=$(ZEP_DEVICES))
+
+# enable the ZEP dispatcher
+FLAGS_EXTRAS += -z $(ZEP_PORT_BASE)
+
+TERMPROG_FLAGS = $(FLAGS_EXTRAS) $(ELFFILE) $(HOST_IPV6)
+TERMPROG ?= sudo $(RIOTTOOLS)/zep_dispatch/start_network.sh $(TERMPROG_FLAGS)
+
+# -z [::1]:$PORT for each ZEP device
+TERMFLAGS ?= $(patsubst %,-z [::1]:%, $(shell seq $(ZEP_PORT_BASE) $(ZEP_PORT_MAX)))
+
+# set optional ZEP l2 address
+ifneq (,$(ZEP_MAC))
+  TERMFLAGS += --eui64=$(ZEP_MAC)
+endif

--- a/firmware/network/chamos/chamos.c
+++ b/firmware/network/chamos/chamos.c
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * @brief   CHAMOS  Communication Handler for Addressing Management | Origin Server
  *
@@ -31,7 +32,7 @@
 #define SERVER_BUFFER_SIZE (CONFIG_SERVER_BUFFER_SIZE)
 
 gnrc_netif_t *_netif;
-sock_udp_t chamos_sock = {};
+sock_udp_t chamos_sock;
 char chamos_stack[THREAD_STACKSIZE_DEFAULT];
 
 int server_send_ack(chamos_msg_t *msg, sock_udp_ep_t *remote, bool flag_ack_val) {

--- a/firmware/network/radio/radio.c
+++ b/firmware/network/radio/radio.c
@@ -30,7 +30,8 @@
 #include "net/netdev.h"
 #include "radio.h"
 
-static uint8_t radio_devices[] = {NETDEV_AT86RF215, NETDEV_AT86RF2XX, NETDEV_CC2538};
+static uint8_t radio_devices[] = {NETDEV_AT86RF215, NETDEV_AT86RF2XX, NETDEV_CC2538,
+                                  NETDEV_SOCKET_ZEP};
 
 #ifdef CONFIG_MODE_SUB_24GHZ
 int8_t subtract_to_interface = 1;


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
These features allow use the socket_zep and zep_dispatcher tool, to simulate an radio network. You could use various border_router in a radio simulated network modifying the `TAP`and `PORT`parameters. Remember that you also need to refer the type board as native to work with socket_zep. (by default is set m4a-24g board). 

*Note*: Don't reboot the border routers during their use, you will get the settings of the last built border_Router tap example.

### Testing procedure
Open the foren 6, and select play. [more about foren6](https://cetic.github.io/foren6/), only available through a [fork](https://github.com/benpicco/foren6)
start running zep_dispatch in another terminal
```sh
cd RIOT/dist/tools/zep_dispatch
make run
```
Build, flash and open terminal of the example
```
make -C examples/border_router/ BOARD=native TAP=tap[n] PORT=tap[n] menuconfig all term
```
where n is the tap_id (~could be~ must be a unique id for each tap) 

The test model has one DODAG border_router and them set to DAG Border_router. All these parameter as seteable under kernel configuration (Kconfig) of the example. and will provide the option to change ipv6 address of wireless interface (Option only available to DODAG Border_Router). 

### Issues/PRs references
None
