### PR TITLE
firmware/sys/uniqueid: get_uid_seed and net_tools set_ipv6_by_uid

### DIFF
--- a/firmware/network/net_tools/include/net_tools.h
+++ b/firmware/network/net_tools/include/net_tools.h
@@ -44,7 +44,8 @@
 extern "C" {
 #endif
 
-#define PREFIX_LSHIFTTED_BITS   (8)
+#define BITS_IN_A_BYTE        (8)
+#define PREFIX_LSHIFTTED_BITS (8)
 
 /**
  * @brief Function to check if exist a wired interface
@@ -70,7 +71,7 @@ int8_t get_ipv6_global(kernel_pid_t iface_pid, ipv6_addr_t *addr);
  *
  * @param[in] iface_index  index that will be save the ipv6 address.
  * @param[in] ip Address ipv6 global to set.
- * @param[in] prefix Networks prefix,express the subnet size.
+ * @param[in] prefix Networks prefix represent the subnet size.
  * @retval 0 Correctly set up of the @p ip in the interface.
  * @retval -1 Couldn't set the @p ip address in the interface.
  */
@@ -81,12 +82,27 @@ int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip, uint8_t prefix)
  *
  * @param[in] iface_index  index that will be save the ipv6 address.
  * @param[in] ip Address ipv6 multicast to set
- * @param[in] prefix Networks prefix,express the subnet size.
+ * @param[in] prefix Networks prefix represent the subnet size.
  * @retval  0 Correctly set up of the @p ip in the interface.
  * @retval -1 Couldn't set the @p ip address in the interface.
  */
 int8_t set_ipv6_multicast(kernel_pid_t iface_index, ipv6_addr_t ip, uint8_t prefix);
 
+#if (MODULE_UNIQUEID) || (DOXYGEN)
+/**
+ * @brief Function to set an ipv6 global address in an iface.
+ *
+ * @param[in] iface_index  index that will be save the ipv6 address.
+ * @param[inout] ip Address ipv6 to set. the octets of the required IPv6 address should be
+ * previously defined (depending on the network prefixes)
+ * @param[in] prefix Networks prefix represent the subnet size.
+ * @param uid_mode define if the uniqueid generate random or static ipv6 address
+ * @retval  0 Correctly set up of the @p ip in the interface.
+ * @retval -1 Couldn't set the @p ip address in the interface.
+ */
+int8_t set_ipv6_by_uid(const kernel_pid_t iface_index, ipv6_addr_t *ip, const uint8_t prefix,
+                       const uint8_t uid_mode);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/firmware/network/net_tools/net_tools.c
+++ b/firmware/network/net_tools/net_tools.c
@@ -100,16 +100,18 @@ int8_t set_ipv6_by_uid(const kernel_pid_t iface_index, ipv6_addr_t *ip, const ui
     case UNIQUEID_STATIC_MODE:
         DEBUG("Setting ipv6 via uniqueid static mode\n");
         get_uid_seed(ip->u8 + pfx_pos, pfx_bytes, uid_mode);
-        set_ipv6_global(iface_index, *ip, prefix);
-        return 0;
+        break;
     case UNIQUEID_RANDOM_MODE:
         DEBUG("Setting ipv6 via uniqueid random mode\n");
         get_uid_seed(ip->u8 + pfx_pos, pfx_bytes, uid_mode);
-        return 0;
-    default:
         break;
+    default:
+        return -1;
     }
-    return -1;
+    if (set_ipv6_global(iface_index, *ip, prefix) < 0) {
+        return -1;
+    }
+    return 0;
 }
 #endif
 int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip, uint8_t prefix) {

--- a/firmware/network/net_tools/net_tools.c
+++ b/firmware/network/net_tools/net_tools.c
@@ -37,6 +37,9 @@
 #include "net_tools.h"
 #include "net/ipv6/addr.h"
 #include "net/gnrc/netif.h"
+#if MODULE_UNIQUEID
+#include "uniqueid.h"
+#endif
 
 #if (CONFIG_DEBUG_NET_TOOLS) || (DOXYGEN)
 /**
@@ -83,6 +86,32 @@ int8_t get_ipv6_global(kernel_pid_t iface_pid, ipv6_addr_t *addr) {
     return -1;
 }
 
+#if MODULE_UNIQUEID
+int8_t set_ipv6_by_uid(const kernel_pid_t iface_index, ipv6_addr_t *ip, const uint8_t prefix,
+                       const uint8_t uid_mode) {
+    uint8_t pfx_pos = prefix / BITS_IN_A_BYTE;
+    uint8_t pfx_bytes = sizeof(ipv6_addr_t) - pfx_pos;
+    if (prefix > 128) {
+        DEBUG("Wrong prefix length\n"
+              "File: %s, Function: %s, Line: %d\n",
+              __FILE__, __func__, __LINE__);
+    }
+    switch (uid_mode) {
+    case UNIQUEID_STATIC_MODE:
+        DEBUG("Setting ipv6 via uniqueid static mode\n");
+        get_uid_seed(ip->u8 + pfx_pos, pfx_bytes, uid_mode);
+        set_ipv6_global(iface_index, *ip, prefix);
+        return 0;
+    case UNIQUEID_RANDOM_MODE:
+        DEBUG("Setting ipv6 via uniqueid random mode\n");
+        get_uid_seed(ip->u8 + pfx_pos, pfx_bytes, uid_mode);
+        return 0;
+    default:
+        break;
+    }
+    return -1;
+}
+#endif
 int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip, uint8_t prefix) {
     if (prefix > 128) {
         DEBUG("Wrong prefix length\n"
@@ -100,8 +129,8 @@ int8_t set_ipv6_global(kernel_pid_t iface_index, ipv6_addr_t ip, uint8_t prefix)
     if (netif_set_opt(iface, NETOPT_IPV6_ADDR, flags, &ip, sizeof(ipv6_addr_t)) <
         PREFIX_LSHIFTTED_BITS) {
         DEBUG("error: unable to add IPv6 address\n"
-               "File: %s, Function: %s, Line: %d\n",
-               __FILE__, __func__, __LINE__);
+              "File: %s, Function: %s, Line: %d\n",
+              __FILE__, __func__, __LINE__);
         return -1;
     }
     return 0;

--- a/firmware/network/rpl_protocol/Makefile.dep
+++ b/firmware/network/rpl_protocol/Makefile.dep
@@ -1,9 +1,7 @@
 USEMODULE += radio
 USEMODULE += gnrc_rpl
 USEMODULE += auto_init_gnrc_rpl
-USEMODULE += uniqueid
 USEMODULE += gnrc_ipv6_router_default
-USEMODULE += net_tools
 
 ifneq (,$(filter 6lpan_node,$(USEMODULE)))
      USEMODULE += gnrc_sixlowpan_router_default

--- a/firmware/network/rpl_protocol/rpl_protocol.c
+++ b/firmware/network/rpl_protocol/rpl_protocol.c
@@ -20,8 +20,6 @@
 #include "net/gnrc/rpl.h"
 #include "rpl_protocol.h"
 #include "radio.h"
-#include "net_tools.h"
-#include "uniqueid.h"
 
 #if (CONFIG_DEBUG_RPL_PROTOCOL) || (DOXYGEN)
 /**
@@ -102,15 +100,6 @@ int8_t rpl_setup(uint8_t mode) {
         return -1;
     }
     if (mode == DODAG || CONFIG_IS_DODAG == DODAG) {
-        err = get_ipv6_global(iface_index, &ip);
-        if (err < 0) {
-            get_uid_ipv6(&ip, KCONFIG_UID_OPTION || UNIQUEID_STATIC_MODE);
-            if (gnrc_netif_ipv6_addr_add(gnrc_netif_get_by_pid(iface_index), &ip, 64,
-                                         GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID) < 0) {
-                DEBUG("Error: Couldn't add IPv6 global address\n");
-                return -1;
-            }
-        }
         err = gnrc_rpl_dodag_root(CONFIG_DODAG_INSTANCE, &ip);
         if (err < 0) {
             DEBUG("Error: Rpl root node ipv6 couldn't set ipv6 global address, File: %s line: %d\n",

--- a/firmware/sys/uniqueid/Makefile.dep
+++ b/firmware/sys/uniqueid/Makefile.dep
@@ -3,11 +3,3 @@ USEMODULE += ipv6_addr
 USEMODULE += netdev_default
 USEMODULE += gnrc_ipv6_default
 USEMODULE += auto_init_gnrc_netif
-
-ifneq (,$(filter at86rf2xx at86rf215,$(USEMODULE)))
-    USEMODULE += radio
-else
-    ifneq (,$(filter periph_hwrng,$(HAS_PERIPH_HWRNG)))
-        USEMODULE += periph_hwrng
-    endif
-endif

--- a/firmware/sys/uniqueid/include/uniqueid.h
+++ b/firmware/sys/uniqueid/include/uniqueid.h
@@ -77,7 +77,7 @@ union random_buff {
  */
 void get_uid_ipv6(ipv6_addr_t *addr, uniqueid_mode_t mode);
 
-uint32_t get_uid_seed(void *val, const uint8_t len);
+uint32_t get_uid_seed(void *val, uint8_t len, uint8_t uid_mode);
 #ifdef __cplusplus
 }
 #endif

--- a/firmware/sys/uniqueid/include/uniqueid.h
+++ b/firmware/sys/uniqueid/include/uniqueid.h
@@ -73,11 +73,13 @@ union random_buff {
 };
 /**
  * @brief This function get ipv6 address (mode: static (default), random, manual)
- * @param [out] addr Address in ipv6 format
+ * @param [out] val any value type where will saved the seed.
+ * @param [in] len  size in number of bytes of @p val.
+ * @param [in] uid_mode defines the uniqueid mode, refers random or static mode.
+ *
  */
-void get_uid_ipv6(ipv6_addr_t *addr, uniqueid_mode_t mode);
+void get_uid_seed(void *val, uint8_t len, uint8_t uid_mode);
 
-uint32_t get_uid_seed(void *val, uint8_t len, uint8_t uid_mode);
 #ifdef __cplusplus
 }
 #endif

--- a/firmware/sys/uniqueid/uniqueid.c
+++ b/firmware/sys/uniqueid/uniqueid.c
@@ -25,8 +25,10 @@
 #include <string.h>
 #include "uniqueid.h"
 #include "random.h"
+#if (MODULE_AT86RF2XX || MODULE_AT86RF215)
 #include "net/netdev/ieee802154.h"
 #include "net/gnrc.h"
+#endif
 #if MODULE_PERIPH_HWRNG
 #include "periph/hwrng.h"
 #endif
@@ -42,7 +44,7 @@
 #endif
 #include "debug.h"
 
-uint32_t get_uid_seed(void *val, uint8_t len, uint8_t uid_mode) {
+void get_uid_seed(void *val, uint8_t len, uint8_t uid_mode) {
     uint32_t rval;
     uint8_t cpuid_bytes = CPUID_LEN / 2;
     char addr_cpu[CPUID_LEN];
@@ -81,6 +83,5 @@ uint32_t get_uid_seed(void *val, uint8_t len, uint8_t uid_mode) {
     default:
         break;
     }
-
-    return 0;
+    return;
 }

--- a/tests/net_rpl/Makefile
+++ b/tests/net_rpl/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += embunit
 USEMODULE += uniqueid
 USEMODULE += rpl_protocol
+USEMODULE += net_tools
 USEMODULE += radio
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/net_rpl/main.c
+++ b/tests/net_rpl/main.c
@@ -25,30 +25,28 @@
 #include "embUnit.h"
 #include "uniqueid.h"
 #include "rpl_protocol.h"
+#include "net_tools.h"
 #include "radio.h"
 
 #define IFACE_ID 4
 #define DODAG_INSTANCE 1
 
 void test_init_rpl(void) {
-   int err = rpl_init(IFACE_ID);
-   TEST_ASSERT_EQUAL_INT(0, err);
+    int err = rpl_init(IFACE_ID);
+    TEST_ASSERT_EQUAL_INT(0, err);
 }
 
 void test_add_dodag_node(void) {
     ipv6_addr_t ipv6 = {
-        .u8 = {0},
+        .u8 = {0x20, 0x01, 0x0d, 0xb8, 0x00, 0x02, 0x00, 0x01},
     };
-
-    subnet_to_ipv6(&ipv6);
     uint8_t iface_index = get_ieee802154_iface();
-    gnrc_netif_ipv6_addr_add(gnrc_netif_get_by_pid(iface_index), &ipv6, 64,
-                                     GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
+    set_ipv6_by_uid(iface_index, &ipv6, 64, UNIQUEID_STATIC_MODE);
     int err = gnrc_rpl_dodag_root(DODAG_INSTANCE, &ipv6);
     TEST_ASSERT_EQUAL_INT(0, err);
 }
 
-void test_remove_dodag_node (void) {
+void test_remove_dodag_node(void) {
     int err = rpl_dodag_remove(DODAG_INSTANCE);
     TEST_ASSERT_EQUAL_INT(0, err);
 }

--- a/tests/system_uniqueid/Makefile
+++ b/tests/system_uniqueid/Makefile
@@ -2,5 +2,6 @@ include ../Makefile.tests_common
 
 USEMODULE += embunit
 USEMODULE += uniqueid
+USEMODULE += net_tools
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/system_uniqueid/main.c
+++ b/tests/system_uniqueid/main.c
@@ -28,29 +28,58 @@
 #include "embUnit.h"
 #include "uniqueid.h"
 #include "unique_random.h"
+#include "net_tools.h"
 
 ipv6_addr_t addr;
 
-void test_get_ipv6_static(void){
-    get_uid_ipv6(&addr, UNIQUEID_STATIC_MODE);
+void test_get_uid_seed_static(void) {
+    uint8_t val[CPUID_LEN / 2];
+    get_uid_seed(val, sizeof(val), UNIQUEID_STATIC_MODE);
+    printf("CPUID seed in hex: ");
+    for (uint8_t i = 0; i < sizeof(val); i++) {
+        printf("%02X ", val[i]);
+    }
+    printf("\n");
+    printf("CPUID seed in uint32: %" PRIu32 "\n", (uint32_t)val);
+}
+
+void test_get_uid_seed_random(void) {
+    uint32_t val = 0;
+    get_uid_seed(&val, sizeof(val), UNIQUEID_RANDOM_MODE);
+    printf("Random seed in hex: ");
+    for (uint8_t i = sizeof(val); i > 0; i--) {
+        printf("%02X ", (uint8_t)((val >> (i - 1) * BITS_IN_A_BYTE)));
+    }
+    printf("\n");
+    printf("random seed in uint32: %" PRIu32 "\n", val);
+}
+
+void test_get_ipv6_static(void) {
+    uint8_t iface = get_wired_iface();
+    ipv6_addr_from_str(&addr, "2001:db8:2:1::");
+    set_ipv6_by_uid(iface, &addr, 64, UNIQUEID_STATIC_MODE);
     ipv6_addr_print(&addr);
     printf("\n");
 }
 
-void test_get_ipv6_random(void){
-    get_uid_ipv6(&addr, UNIQUEID_RANDOM_MODE);
+void test_get_ipv6_random(void) {
+    uint8_t iface = get_wired_iface();
+    ipv6_addr_from_str(&addr, "2001:db8:2:1::");
+    set_ipv6_by_uid(iface, &addr, 64, UNIQUEID_RANDOM_MODE);
     ipv6_addr_print(&addr);
     printf("\n");
 }
 
-void test_uid_random_blocks(void){
-    random_generator(64);
-}
+void test_randomblocks(void) { random_generator(8); }
+
+void test_uid_random_blocks(void) { random_generator(64); }
 
 Test *tests_get_unique_id(void) {
     EMB_UNIT_TESTFIXTURES(fixtures){
-        new_TestFixture(test_get_ipv6_static),
-        new_TestFixture(test_get_ipv6_random),
+        new_TestFixture(test_get_uid_seed_static), new_TestFixture(test_get_uid_seed_random),
+        new_TestFixture(test_get_ipv6_static),     new_TestFixture(test_get_ipv6_random),
+        new_TestFixture(test_randomblocks),
+
     };
 
     EMB_UNIT_TESTCALLER(tests_get_unique_id, NULL, NULL, fixtures);

--- a/tests/system_uniqueid/random_gen.c
+++ b/tests/system_uniqueid/random_gen.c
@@ -26,17 +26,9 @@
 #include "random.h"
 #include "unique_random.h"
 
-#if (MODULE_AT86RF2XX || MODULE_AT86RF215)
-#include "radio.h"
-#endif
 #define BIT_ON_MASK (0x01)
 
 void random_generator(uint8_t bit_ref) {
-
-#if (MODULE_AT86RF2XX || MODULE_AT86RF215)
-    int index = get_ieee802154_iface();
-    netif_t *iface = netif_get_by_id(index);
-#endif
     uint8_t avg_bit32 = bit_ref / 32;
     if (bit_ref % 32 != 0) {
         avg_bit32++;
@@ -45,12 +37,8 @@ void random_generator(uint8_t bit_ref) {
     for (uint8_t i = 0; i < bit_ref; i++) {
         printf("ref %u", (uint8_t)(i + 1));
         for (uint8_t j = 0; j < avg_bit32; j++) {
-#if (MODULE_AT86RF2XX || MODULE_AT86RF215)
-            netif_get_opt(iface, NETOPT_RANDOM, 0, &random_byte_block, sizeof(uint32_t));
-#endif
-            random_init(random_byte_block);
-            random_byte_block = random_uint32();
-            printf(" Block: %d\t%" PRIx32 " \t", j, random_byte_block);
+            get_uid_seed(&random_byte_block, sizeof(random_byte_block), UNIQUEID_RANDOM_MODE);
+            printf(" Block: %d\t 0x%" PRIx32 " \t", j, random_byte_block);
             print_binary(random_byte_block, bit_ref / avg_bit32);
             printf("\t");
         }


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
The uniqueid module was modified to only generate a random or statically seed (Whatever mode that is required). You could get a value from the cpuid, the seed requires to know the length of the passed storage value (`len`), if the length is biggert than CPUID_LEN in bytes,  The rest of the remaining bytes will be filled with random values.
To net_tools set_ipv6_by_uid only will be used is module uniqueid is added. you always need to add the ipv6_header that is pre-defined by the prefix length. e.g  prefix will be used "/56" the address "[2001:db8:0021:15]()xx:xxxx:xxxxx:xxxxx:xxxx", each "x" refers to a value that can be altered by the `uid_seed`. 
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
```
make -C tests/system_uniqueid flash term
```

<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
