### PR TITLE
wifi-subsys: fix GA copyright warning

### DIFF
--- a/wifi-subsys/test/main/main.c
+++ b/wifi-subsys/test/main/main.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2022 Mesh4all <mesh4all.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @brief       Main unit-test file
+ *
+ * @author      luisan00 <luisan00@hotmail.com>
+ *
+ */
+
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
### Contribution description
Fix a warning about copyright, it is  detected by static-tests runners for `wifi-subsys/test/main/main.c`
### Testing procedure
Once the GA runners finished, check if the warning still exists for the file `wifi-subsys/test/main/main.c`

### Issues/PRs references
None 