### PR TITLE
firmware/sys/storage: Added supports to save specified data types

### DIFF
--- a/firmware/sys/storage/Makefile.dep
+++ b/firmware/sys/storage/Makefile.dep
@@ -1,5 +1,4 @@
 USEMODULE += mtd_flashpage
-USEMODULE += mtd_write_page
 
 ifneq (,$(filter storage,$(USEMODULE)))
   FEATURES_REQUIRED += periph_flashpage

--- a/firmware/sys/storage/include/storage.h
+++ b/firmware/sys/storage/include/storage.h
@@ -75,7 +75,7 @@ int8_t mtd_start(void);
  * @param [in] offset reference to an position in mtd_storage.
  * @return int8_t
  */
-int mtd_save(void *value, uint32_t len, uint32_t offset);
+int mtd_save(const void *value, uint32_t len, uint32_t offset);
 
 /**
  * @brief Loads any value in any position of mtd_storage.
@@ -95,7 +95,7 @@ int mtd_load(void *value, uint16_t len, uint32_t offset);
  * @param [in] len size of @p value that will be saved.
  * @return int8_t
  */
-int mtd_save_reg(void *value, uint8_t *key, uint16_t len);
+int mtd_save_reg(const void *value, const uint8_t *key, uint16_t len);
 
 /**
  * @brief Load data from mtd_storage localizating with its knew key and saves in @p value the data.
@@ -108,7 +108,7 @@ int mtd_save_reg(void *value, uint8_t *key, uint16_t len);
  * value parameter.
  * @return int8_t
  */
-int mtd_load_reg(void *value, uint8_t *key, uint16_t len);
+int mtd_load_reg(void *value, const uint8_t *key, uint16_t len);
 
 /**
  * @brief Removes all saved data in mtd_storage. This will erase all until the
@@ -147,6 +147,130 @@ int8_t mtd_dump(void);
  * @return int8_t
  */
 int8_t mtd_dump_flashpage(uint16_t page);
+
+/* Unsigned int put/get operations */
+
+/**
+ * @brief Saves an unsigned int 8 bits data type in the mtd_storage.
+ *
+ * @param [in] value uint8_t data.
+ * @param [in] key An unique identifier string for the uint8_t data @p value.
+ * @return int
+ */
+int mtd_put_u8(const uint8_t value, const uint8_t *key);
+/**
+ * @brief Saves an unsigned int 16 bits data type in the mtd_storage.
+ *
+ * @param [in] value uint16_t data.
+ * @param [in] key An unique identifier string for the uint16_t data @p value.
+ * @return int
+ */
+int mtd_put_u16(const uint16_t value, const uint8_t *key);
+/**
+ * @brief Saves an unsigned int 32 bits data type in the mtd_storage.
+ *
+ * @param [in] value uint32_t data.
+ * @param [in] key An unique identifier string for the uint32_t data @p value.
+ * @return int
+ */
+int mtd_put_u32(const uint32_t value, const uint8_t *key);
+/**
+ * @brief Load an unsigned int 8 bits data type in the mtd_storage
+ *
+ * @param [out] value uint8_t data variable that will load the value from mtd_storage
+ * @param [in] key An unique identifier string for the uint8_t data @p value.
+ * @return int
+ */
+int mtd_get_u8(uint8_t *value, const uint8_t *key);
+/**
+ * @brief Load an unsigned int 16 bits data type in the mtd_storage
+ *
+ * @param [out] value uint16_t data variable that will load the value from mtd_storage
+ * @param [in] key An unique identifier string for the uint16_t data @p value.
+ * @return int
+ */
+int mtd_get_u16(uint16_t *value, const uint8_t *key);
+/**
+ * @brief Load an unsigned int 32 bits data type in the mtd_storage
+ *
+ * @param [out] value uint32_t data variable that will load the value from mtd_storage
+ * @param [in] key An unique identifier string for the uint32_t data @p value.
+ * @return int
+ */
+int mtd_get_u32(uint32_t *value, const uint8_t *key);
+
+/* Int put/set operations */
+
+/**
+ * @brief Saves a signed int 8 bits data type in the mtd_storage.
+ *
+ * @param [in] value int8_t data.
+ * @param [in] key An unique identifier string for the int8_t data @p value.
+ * @return int
+ */
+int mtd_put_i8(const int8_t value, const uint8_t *key);
+/**
+ * @brief Saves an signed int 16 bits data type in the mtd_storage.
+ *
+ * @param [in] value uint16_t data.
+ * @param [in] key An unique identifier string for the uint16_t data @p value.
+ * @return int
+ */
+int mtd_put_i16(const int16_t value, const uint8_t *key);
+/**
+ * @brief Saves an signed int 32 bits data type in the mtd_storage.
+ *
+ * @param [in] value uint32_t data.
+ * @param [in] key An unique identifier string for the uint32_t data @p value.
+ * @return int
+ */
+int mtd_put_i32(const int32_t value, const uint8_t *key);
+/**
+ * @brief Load an signed int 8 bits data type in the mtd_storage
+ *
+ * @param [out] value int8_t data variable that will load the value from mtd_storage
+ * @param [in] key An unique identifier string for the int8_t data @p value.
+ * @return int
+ */
+int mtd_get_i8(int8_t *value, const uint8_t *key);
+/**
+ * @brief Load an unsigned int 16 bits data type in the mtd_storage
+ *
+ * @param [out] value int16_t data variable that will load the value from mtd_storage
+ * @param [in] key An unique identifier string for the int16_t data @p value.
+ * @return int
+ */
+int mtd_get_i16(int16_t *value, const uint8_t *key);
+/**
+ * @brief Load an unsigned int 32 bits data type in the mtd_storage
+ *
+ * @param [out] value uint32_t data variable that will load the value from mtd_storage
+ * @param [in] key An unique identifier string for the uint32_t data @p value.
+ * @return int
+ */
+int mtd_get_i32(int32_t *value, const uint8_t *key);
+
+/* String put/set operations */
+
+/**
+ * @brief Saves a string with its identifier.
+ * @note it needs to specify the data string length.
+ *
+ * @param [in] value pointer to a string, points to a data string
+ * @param [in] key An unique identifier string for the string data @p value.
+ * @param [in] len size of @p value string.
+ * @return int
+ */
+int mtd_put_str(const char *value, const uint8_t *key, uint8_t len);
+/**
+ * @brief Loads a string using its identifier.
+ *
+ * @param [out] value pointer to a string, points to a data string
+ * @param [in] key An unique identifier string for the string data @p value.
+ * @param [in] len size of @p value string.
+ * @return int
+ */
+int mtd_get_str(char *value, const uint8_t *key, uint8_t len);
 
 #ifdef __cplusplus
 }

--- a/tests/system_storage/Kconfig
+++ b/tests/system_storage/Kconfig
@@ -2,5 +2,7 @@ rsource "../../firmware/sys/storage/Kconfig"
 rsource "../../firmware/Kconfig.debug"
 
 menu "Test Debug"
-
+    config DEBUG_TEST_STORAGE
+            bool "Debugging storage Test"
+            default n
 endmenu

--- a/tests/system_storage/Makefile
+++ b/tests/system_storage/Makefile
@@ -2,6 +2,7 @@ include ../Makefile.tests_common
 
 USEMODULE += embunit
 USEMODULE += storage
+
 # USEMODULE += radio
 # USEMODULE += rpl_protocol
 

--- a/tests/system_storage/main.c
+++ b/tests/system_storage/main.c
@@ -28,7 +28,17 @@
 
 #include "storage.h"
 #include "mtd.h"
+
+#if (CONFIG_DEBUG_TEST_STORAGE) || (DOXYGEN)
+/**
+ * @brief KCONFIG_PARAMETER TO SET DEBUG MODE
+ *
+ */
+#define ENABLE_DEBUG CONFIG_DEBUG_TEST_STORAGE
+#else
 #define ENABLE_DEBUG 0
+#endif
+
 #include "debug.h"
 
 struct val {
@@ -101,26 +111,45 @@ void test_saving_reg(void) {
     char str[28] = {"Everyone in the mesh!!!"};
     char str2[20] = {"Contributor: CW"};
     uint8_t age = 24;
+    uint16_t port = 4094;
     uint32_t u32_val = 155556;
+    int8_t i8val = -123;
+    int16_t i16val = -3258;
+    int32_t i32val = -9000;
 
-    ret = mtd_save_reg(str, (uint8_t *)"KEY0", sizeof(str));
+    ret = mtd_put_str(str, (uint8_t *)"KEY0", sizeof(str));
     if (ret < 0) {
         DEBUG("Failed Saving data");
     }
     printf("\n");
-    ret = mtd_save_reg(str2, (uint8_t *)"KEY1", sizeof(str2));
+    ret = mtd_put_str(str2, (uint8_t *)"KEY1", sizeof(str2));
     if (ret < 0) {
         DEBUG("Failed Saving data\n");
     }
-    ret = mtd_save_reg(str, (uint8_t *)"KEY0", sizeof(str));
+    ret = mtd_put_u8(age, (uint8_t *)"KEY2");
     if (ret < 0) {
         DEBUG("Failed Saving data\n");
     }
-    ret = mtd_save_reg(&age, (uint8_t *)"KEY2", sizeof(age));
+    ret = mtd_put_u16(port, (uint8_t *)"KEY3");
     if (ret < 0) {
         DEBUG("Failed Saving data\n");
     }
-    ret = mtd_save_reg(&u32_val, (uint8_t *)"KEY3", sizeof(u32_val));
+    ret = mtd_put_u32(u32_val, (uint8_t *)"KEY4");
+    if (ret < 0) {
+        DEBUG("Failed Saving data\n");
+    }
+    ret = mtd_put_i8(i8val, (uint8_t *)"KEY5");
+    if (ret < 0) {
+        DEBUG("Failed Saving data\n");
+    }
+    ret = mtd_put_i16(i16val, (uint8_t *)"KEY6");
+    if (ret < 0) {
+        DEBUG("Failed Saving data\n");
+    }
+    ret = mtd_put_i32(i32val, (uint8_t *)"KEY7");
+    if (ret < 0) {
+        DEBUG("Failed Saving data\n");
+    }
     mtd_available_idx();
     TEST_ASSERT_EQUAL_INT(0, ret);
     mtd_dump();
@@ -130,13 +159,13 @@ void test_loading_reg(void) {
     int ret = 0;
     char str[28];
     char str2[20];
-    uint32_t u32_val;
     uint8_t age;
-    ret = mtd_load_reg(str, (uint8_t *)"KEY0", sizeof(str));
-    if (ret < 0) {
-        DEBUG("Failed Loading data");
-    }
-    ret = mtd_load_reg(&u32_val, (uint8_t *)"KEY3", sizeof(u32_val));
+    uint16_t port;
+    uint32_t u32_val;
+    int8_t i8val;
+    int16_t i16val;
+    int32_t i32val;
+    ret = mtd_get_str(str, (uint8_t *)"KEY0", sizeof(str));
     if (ret < 0) {
         DEBUG("Failed Loading data");
     }
@@ -144,13 +173,36 @@ void test_loading_reg(void) {
     if (ret < 0) {
         DEBUG("Failed Loading data");
     }
-    ret = mtd_load_reg(&age, (uint8_t *)"KEY2", sizeof(age));
+    ret = mtd_get_u8(&age, (uint8_t *)"KEY2");
+    if (ret < 0) {
+        DEBUG("Failed Loading data");
+    }
+    ret = mtd_get_u16(&port, (uint8_t *)"KEY3");
+    if (ret < 0) {
+        DEBUG("Failed Loading data");
+    }
+    ret = mtd_get_u32(&u32_val, (uint8_t *)"KEY4");
+    if (ret < 0) {
+        DEBUG("Failed Loading data");
+    }
+    ret = mtd_get_i8(&i8val, (uint8_t *)"KEY5");
+    if (ret < 0) {
+        DEBUG("Failed Loading data");
+    }
+    ret = mtd_get_i16(&i16val, (uint8_t *)"KEY6");
+    if (ret < 0) {
+        DEBUG("Failed Loading data");
+    }
+    ret = mtd_get_i32(&i32val, (uint8_t *)"KEY7");
 
-    printf("String#1 loaded: %s\n", str);
-    printf("String#2 loaded: %s\n", str2);
-    printf("Uint32_t loaded: %" PRIu32 "\n", u32_val);
-    printf("Uint8_t loaded: %d\n", age);
-
+    printf("string#1 loaded: %s\n", str);
+    printf("string#2 loaded: %s\n", str2);
+    printf("uint8_t loaded: %d\n", age);
+    printf("uint16_t loaded: %" PRIu16 "\n", port);
+    printf("uint32_t loaded: %" PRIu32 "\n", u32_val);
+    printf("int8_t loaded: %d\n", i8val);
+    printf("int16_t loaded: %" PRId16 " \n", i16val);
+    printf("int32_t loaded: %" PRId32 " \n", i32val);
     TEST_ASSERT_EQUAL_INT(0, ret);
 }
 


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
Was Added support to provide an specified data types registers, can be processed `uint8_t`, `uint16_t`, and `uint32_t` for all unsigned data types, for signed datatypes `ìnt8_t`, `int16_t` and `ìnt32_t`, also could be processed `strings` data types, only specifying its length.
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
run the storage test. `tests/system_storage/`
```
make -C tests/system_storage flash term
```
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
