### PR TITLE
firmware/network/radio: Radio module fixed `gets` functions

### DIFF
--- a/firmware/network/radio/include/radio.h
+++ b/firmware/network/radio/include/radio.h
@@ -47,13 +47,13 @@ int8_t get_ieee802154_iface(void);
  * @brief this function is used to get data of tx power
  * @param[in] txpower channel you want to get
  */
-int8_t get_netopt_tx_power(int16_t txpower);
+int8_t get_netopt_tx_power(int16_t *txpower);
 
 /**
  * @brief this function is used to get data of channel
  * @param[in] channel channel you want to get
  */
-int8_t get_netopt_channel(int16_t channel);
+int8_t get_netopt_channel(uint16_t *channel);
 
 /**
  * @brief this function is used to set the channel
@@ -61,7 +61,7 @@ int8_t get_netopt_channel(int16_t channel);
  * @param[in] channel channel you want to set
  * @note the device has channels between 11 to 26
  */
-int8_t set_netopt_channel(int16_t channel);
+int8_t set_netopt_channel(uint16_t channel);
 
 /**
  * @brief this function is used to set the tx power

--- a/tests/driver_radio/Kconfig
+++ b/tests/driver_radio/Kconfig
@@ -1,1 +1,2 @@
+rsource "../../firmware/Kconfig.debug"
 rsource "../../firmware/network/radio/Kconfig"

--- a/tests/driver_radio/main.c
+++ b/tests/driver_radio/main.c
@@ -17,9 +17,12 @@
  * @brief       Radio file
  *
  * @author      RocioRojas <rociorojas391@gmail.com>
+ * @author      eduazocar <eduazocarv@gmail.com>
  */
+#include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include "xtimer.h"
 #include "embUnit.h"
 #include "radio.h"
 
@@ -28,15 +31,29 @@ void test_get_ieee802154_iface(void) {
     TEST_ASSERT_EQUAL_INT(0, err);
 }
 
+void test_set_netopt_tx_power(void) {
+    int16_t txpower = 4;
+    int8_t err =  set_netopt_tx_power(txpower);
+    TEST_ASSERT_EQUAL_INT(0, err);
+}
+
 void test_get_netopt_tx_power(void) {
     int16_t txpower=0;
-    int8_t err =  get_netopt_tx_power(txpower);
+    int8_t err =  get_netopt_tx_power(&txpower);
+    printf("Tx Power: %"PRId16"\n", txpower);
+    TEST_ASSERT_EQUAL_INT(0, err);
+}
+
+void test_set_netopt_channel(void) {
+    uint16_t channel= 22;
+    int8_t err = set_netopt_channel(channel);
     TEST_ASSERT_EQUAL_INT(0, err);
 }
 
 void test_get_netopt_channel(void) {
-    int16_t channel=0;
-    int8_t err = get_netopt_channel(channel);
+    uint16_t channel=0;
+    int8_t err = get_netopt_channel(&channel);
+    printf("Channel: %"PRIu16"\n", channel);
     TEST_ASSERT_EQUAL_INT(0, err);
 }
 
@@ -45,10 +62,12 @@ void test_initial_radio_setup(void) {
     TEST_ASSERT_EQUAL_INT(0, err);
 }
 
-Test *tests_radio_module(void) {
+Test *radio_tests(void) {
     EMB_UNIT_TESTFIXTURES(fixtures){
         new_TestFixture(test_get_ieee802154_iface),
+        new_TestFixture(test_set_netopt_tx_power),
         new_TestFixture(test_get_netopt_tx_power),
+        new_TestFixture(test_set_netopt_channel),
         new_TestFixture(test_get_netopt_channel),
         new_TestFixture(test_initial_radio_setup),
     };
@@ -60,7 +79,7 @@ Test *tests_radio_module(void) {
 
 int main(void) {
     TESTS_START();
-    TESTS_RUN(tests_radio_module());
+    TESTS_RUN(radio_tests());
     TESTS_END();
     return 0;
 }


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
Currently the `gets`function from radio module are not returning the tx_power or channel. only are printing in debug mode, within of the function. so, if you want to read the value of `tx_power`or `channel` already it's accessible. 
There is a little delay to set the `tx_power` of radio interface, you can see that in `driver_radio` test. if you remove that delay, you could see the Tx_power in 0. 
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
Run using the `tests/driver_radio`
```
make -C tests/driver_radio flash term
```
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
