### PR TITLE
firmware/sys/shell_extended: Added `stg` commands functions and `se_*` fixes

### DIFF
--- a/examples/shell_extended/Kconfig
+++ b/examples/shell_extended/Kconfig
@@ -1,1 +1,1 @@
-rsource "../../firmware/sys/Kconfig"
+rsource "../../firmware/Kconfig.debug"

--- a/examples/shell_extended/Makefile
+++ b/examples/shell_extended/Makefile
@@ -4,10 +4,14 @@ include ../Makefile.common
 
 # Include the shell extended module, shell and shell commands modules
 # will be implicitly included.
+USEMODULE += shell_commands
 USEMODULE += shell_extended
+# USEMODULE+= border_router
 
 # Include desired modules where shell extended is enabled.
+USEMODULE += radio
 USEMODULE += uniqueid
 USEMODULE += net_tools
+USEMODULE += storage
 
 include $(RIOTBASE)/Makefile.include

--- a/firmware/default_params.h
+++ b/firmware/default_params.h
@@ -63,7 +63,7 @@ typedef struct {
     uint16_t freq;
 } settings_ifaces_t;
 
-#define IF_KEY ("IFKEY")
+#define IF_KEY (uint8_t*)("IFKEY")
 
 /**
  * @name storage address this address will be the storage keys

--- a/firmware/sys/Kconfig
+++ b/firmware/sys/Kconfig
@@ -1,3 +1,6 @@
+
+rsource "../../firmware/Kconfig.debug"
+
 menu "System"
 rsource "uniqueid/Kconfig"
 rsource "serialization/Kconfig"

--- a/firmware/sys/shell_extended/Makefile.include
+++ b/firmware/sys/shell_extended/Makefile.include
@@ -1,2 +1,5 @@
 USEMODULE_INCLUDES_shell_extended := $(LAST_MAKEFILEDIR)/include
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_shell_extended)
+ifneq (,$(filter storage,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/../firmware
+endif

--- a/firmware/sys/shell_extended/se_net_tools.c
+++ b/firmware/sys/shell_extended/se_net_tools.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * @brief   Extends the shell functionality for uniqueid
+ * @brief   Extends the shell functionality for net_tools
  * @author  Luis A. Ruiz    <luisan00@hotmail.com>
  * @author  Eduardo Azócar  <eduazocarv@gmail.com>
  */
@@ -46,11 +46,11 @@ void net_tools_usage(void) {
 int net_tools_cmd(int argc, char **argv) {
     (void)argc;
     (void)argv;
-
-    if ((strcmp(argv[1], "help") == 0)) {
+    if ((argc < 3) || (argc > 6) || (strcmp(argv[1], "help") == 0)) {
         net_tools_usage();
         return 0;
     }
+
     if ((strcmp(argv[2], "add") == 0)) {
         int if_idx = atoi(argv[1]);
         char ip[40] = "";
@@ -62,13 +62,16 @@ int net_tools_cmd(int argc, char **argv) {
         }
 #if MODULE_UNIQUEID
         if (strcmp(argv[3], "ipuid") == 0) {
+            if (argc < 6) {
+                net_tools_usage();
+                return -1;
+            }
             check_inp_addr(argv[4], &addr, &prefix);
             if ((strcmp(argv[5], "static") == 0)) {
                 set_ipv6_by_uid(if_idx, &addr, prefix, UNIQUEID_STATIC_MODE);
                 DEBUG("ipv6 address: %s\n", ipv6_addr_to_str(ip, &addr, sizeof(ip)));
                 return 0;
-            }
-            if ((strcmp(argv[5], "random") == 0)) {
+            } else if ((strcmp(argv[5], "random") == 0)) {
                 set_ipv6_by_uid(if_idx, &addr, prefix, UNIQUEID_RANDOM_MODE);
                 DEBUG("ipv6 address: %s\n", ipv6_addr_to_str(ip, &addr, sizeof(ip)));
                 return 0;
@@ -91,14 +94,10 @@ int net_tools_cmd(int argc, char **argv) {
         }
         show_iface_info(if_idx);
         return 0;
-    }
-
-    if ((argc < 5) || (argc > 5)) {
-        puts("net-tools command needs at least one argument");
+    } else {
         net_tools_usage();
-        return 1;
+        return 0;
     }
-    return 0;
 }
 
 void show_iface_info(kernel_pid_t iface_idx) {

--- a/firmware/sys/shell_extended/se_storage.c
+++ b/firmware/sys/shell_extended/se_storage.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * @brief   Extends the shell functionality for uniqueid
+ * @brief   Extends the shell functionality for storage
  * @author  Luis A. Ruiz    <luisan00@hotmail.com>
  * @author  Eduardo Azócar  <eduazocarv@gmail.com>
  */
@@ -22,36 +22,112 @@
 #include <stdio.h>
 #include <string.h>
 #include "storage.h"
-
-#if MODULE_RADIO
+#include "storage_register.h"
+#include "default_params.h"
 #include "radio.h"
-#endif
 #if MODULE_RPL_PROTOCOL
 #include "rpl_protocol.h"
 #endif
+int8_t stg_save_if_settings(void);
+int8_t stg_del_if_settings(void);
+int8_t stg_load_if_settings(void);
+void build_if_settings(settings_ifaces_t *if_sets, uint8_t num_ifaces);
 
 void storage_usage(void) {
     puts("Storage tool");
     puts("Usage:  stg [save|load|show]");
+    puts("\t\t\t->[iface]");
+    printf("%" PRIu16 " Bytes. \n", sizeof(settings_ifaces_t));
     puts("");
 }
 
 int storage_cmd(int argc, char **argv) {
     (void)argc;
     (void)argv;
-
     if ((argc < 2) || (argc > 2) || (strcmp(argv[1], "help") == 0)) {
-        void storage_usage(void);
+        storage_usage();
         return 0;
     }
-
     if (strcmp(argv[1], "save") == 0) {
-        puts("ToDo: Save all firmware params in mtd storage");
+        stg_save_if_settings();
     } else if (strcmp(argv[1], "load") == 0) {
-        puts("Todo: Load firmware params from mtd storage and are processed");
+        stg_load_if_settings();
     } else if (strcmp(argv[1], "show") == 0) {
         puts("Todo:  show all firmware params saved in mtd storage");
+    } else if (strcmp(argv[1], "del") == 0) {
+        stg_del_if_settings();
     }
-
     return 0;
+}
+
+int8_t stg_save_if_settings(void) {
+    int8_t ret = 0;
+    uint8_t ifaces = gnrc_netif_numof();
+    settings_ifaces_t settings_if[ifaces];
+    build_if_settings(settings_if, ifaces);
+    mtd_reg_del(IF_KEY, sizeof(settings_if));
+    ret = mtd_save_reg(settings_if, IF_KEY, sizeof(settings_if));
+    if (ret < 0) {
+        printf("Failed saving/overwriting the register\n");
+        return ret;
+    }
+    return ret;
+}
+
+int8_t stg_del_if_settings(void) {
+    int8_t ret = 0;
+    uint8_t ifaces = gnrc_netif_numof();
+    ret = mtd_reg_del(IF_KEY, ifaces * sizeof(settings_ifaces_t));
+    return ret;
+}
+
+int8_t stg_load_if_settings(void) {
+    int8_t ret = 0;
+    uint8_t ifaces = gnrc_netif_numof();
+    settings_ifaces_t settings_if[ifaces];
+    ret = mtd_load_reg(settings_if, IF_KEY, sizeof(settings_if));
+    if (ret < 0) {
+        printf("The register doesn't exists, first you need to save the interface info\n");
+        return ret;
+    }
+    for (size_t i = 0; i < ifaces; i++) {
+        printf("Netif_id: %" PRId16 "\n", settings_if[i].id);
+        if (settings_if[i].type == 1) {
+            if (set_netopt_tx_power(settings_if[i].tx_power) < 0) {
+                printf("Failed: loading radio settings [tx_power]\n");
+            }
+            if (set_netopt_channel(settings_if[i].channel) < 0) {
+                printf("Failed: loading radio settings [channel]\n");
+            }
+            printf("Type: Radio iface\n");
+            printf("id: %" PRId16 "\n", settings_if[i].id);
+            printf("Tx power %" PRId16 "\n", settings_if[i].tx_power);
+            printf("Channel: %" PRIu16 "\n", settings_if[i].channel);
+        }
+    }
+    return ret;
+}
+
+void build_if_settings(settings_ifaces_t *if_sets, uint8_t num_ifaces) {
+    gnrc_netif_t *netif = NULL;
+    for (uint8_t i = 0; i < num_ifaces; i++) {
+        netif = gnrc_netif_iter(netif);
+        if (netif->ops != NULL) {
+            if_sets[i].id = netif->pid;
+        }
+        switch (netif->device_type) {
+        case NETDEV_TYPE_IEEE802154:
+            if_sets[i].type = 1;
+            if (get_netopt_tx_power(&if_sets[i].tx_power) < 0) {
+                puts("Err Loading Tx_power");
+            }
+            if (get_netopt_channel(&if_sets[i].channel) < 0) {
+                puts("Err Loading ");
+            }
+            break;
+        default:
+            if_sets[i].type = 0;
+            break;
+        }
+    }
 }

--- a/firmware/sys/storage/storage_internal.c
+++ b/firmware/sys/storage/storage_internal.c
@@ -27,7 +27,6 @@
 #include "mtd.h"
 #include "storage_internal.h"
 
-
 #if (CONFIG_DEBUG_STORAGE) || (DOXYGEN)
 /**
  * @brief KCONFIG_PARAMETER TO SET DEBUG MODE

--- a/tests/driver_radio/main.c
+++ b/tests/driver_radio/main.c
@@ -39,6 +39,7 @@ void test_set_netopt_tx_power(void) {
 
 void test_get_netopt_tx_power(void) {
     int16_t txpower=0;
+    xtimer_sleep(5);
     int8_t err =  get_netopt_tx_power(&txpower);
     printf("Tx Power: %"PRId16"\n", txpower);
     TEST_ASSERT_EQUAL_INT(0, err);

--- a/tests/net_net_tools/main.c
+++ b/tests/net_net_tools/main.c
@@ -77,7 +77,7 @@ void test_rm_global_addr(void) {
     TEST_ASSERT_EQUAL_INT(0, err);
 }
 
-test_set_ipv6(void) {
+void test_set_ipv6(void) {
     ipv6_addr_t ip;
     int err = 0;
     uint8_t iface = get_wired_iface();


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
To use `shell_extended`  storage commands, saves, loads, and deletes, only writing and reading an interface struct defined in #363 (This pr is merged with #363 and #362). implementing radio `gets` and `sets`, these functions allow you save set parameters in the mtd, and after read them, automatically, set that configuration in your own device. 
Another little bugs were fixed from `storage` module, and `shell_extended` module
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
Run the shell_extended example.
```
make -C examples/shell_extended flash term
```

- firs step command line testing (use `ifconfig` to set radio parameters {tx_power, channel} )
```
ifconfig [id radio interface] set power 4
ifconfig [id radio interface] set channel 20
```
- check your settings
```
> ifconfig
2022-10-13 19:48:21,456 # ifconfig
2022-10-13 19:48:21,463 # Iface  4  HWaddr: 4A:D4  Channel: 20  Page: 0  NID: 0x23  PHY: O-QPSK 
2022-10-13 19:48:21,464 #           
2022-10-13 19:48:21,469 #           Long HWaddr: 00:04:25:19:18:01:CA:D4 
2022-10-13 19:48:21,476 #            TX-Power: 4dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
....
```
- Save them in the mtd_storage using `stg save` command.
- reset your device (Press device's reset button or using `reboot`command) .
- After reset use the `stg load` command to load all set parameters before.
### expected output by the `stg load`
```
2022-10-13 19:48:25,264 # Netif_id: [radio interface id]
2022-10-13 19:48:25,266 # Type: Radio iface
2022-10-13 19:48:25,267 # id: [radio interface id]
2022-10-13 19:48:25,268 # Tx power 4
2022-10-13 19:48:25,269 # Channel: 20
```
- after that, check your current setting in your interfaces using `ìfconfig`, the expected output should be the same that step 2.

Also you can delete the interface register.
- write `stg del`in your shell
- check the register using `stg load`
### expected output:
```
2022-10-13 19:47:12,808 # The register doesn't exists, first you need to save the interface info
```
 
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
this depends of #362, #363 
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
