### PR TITLE
CI: drone image versioning

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ type: docker
 name: m4a-24g
 steps:
   - name: build
-    image: luisan00/m4abuild-base:latest
+    image: luisan00/m4abuild-base:20.04
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=m4a-24g
@@ -20,7 +20,7 @@ type: docker
 name: m4a-mb
 steps:
   - name: build
-    image: luisan00/m4abuild-base:latest
+    image: luisan00/m4abuild-base:20.04
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=m4a-mb
@@ -36,7 +36,7 @@ type: docker
 name: meshme
 steps:
   - name: build
-    image: luisan00/m4abuild-base:latest
+    image: luisan00/m4abuild-base:20.04
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=meshme
@@ -52,7 +52,7 @@ type: docker
 name: vs203
 steps:
   - name: build
-    image: luisan00/m4abuild-base:latest
+    image: luisan00/m4abuild-base:20.04
     commands:
       - git submodule update --init --recursive
       - make -C firmware BOARD=vs203


### PR DESCRIPTION
Required in drone.yml to prevent confusions, the image versioning is being changed

### Contribution description

To prevent any chance of confusion, the versioning of images is being changed to match with the version of the base OS.

So for clarification, before this update:

| image                |  tags   | OS version            |
|----------------------|----------|--------------------------| 
| m4abuild-base  | latest  | latest availble Ubuntu LTS |

And after this PR:

| image                |  tags  | OS version     |
|----------------------|---------|--------------------|
| m4abuild-base  | 20.04 | Ubuntu 20.04 |
|                           | 22.04 | Ubuntu 22.04 |

### Testing procedure
Images can be pulled from `https://hub.docker.com/repository/docker/luisan00/m4abuild-base/general` or, for checking the build stage simply go to `https://github.com/Mesh4all/m4a-docker/tree/main/m4abuild-base` and under the path you want to build, execute:

```sh
docker build . -t [user]/[repo]:[dir]
```
changing [user], [repo] and [dir] with the desired values

### Please note

The **latest** tag in Docker Hub will not be removed until we are sure it is no longer needed.

### Issues/PRs references
Nothing