### PR TITLE
ci: fix static-test error with coccinelle

### DIFF
--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -19,7 +19,6 @@ jobs:
 
       - name: Setup code tools
         run: |
-          sudo add-apt-repository ppa:npalix/coccinelle
           sudo apt update
           sudo apt install codespell cppcheck vera++ flake8 uncrustify pcregrep shellcheck doxygen coccinelle
 


### PR DESCRIPTION
### Contribution description
Fix error described in #376 , static-test raise error while trying to add the coccinelle repository



### Testing procedure
Run locally:
```sh
make static-test
```
or look at the  workflow named `static-tests`

### Issues/PRs references
Fix #376 
