### PR TITLE
dist/tools: buildsystem_sanity_check static test bug fixed

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -86,7 +86,7 @@ check_providing_features_only_makefile_features() {
     patterns+=(-e '^[ ]*FEATURES_PROVIDED *+= *')
 
     pathspec+=("*Makefile\.*")
-    pathspec+=(':!dist/tools/m4a-generator/m4agen/templates/board/Makefile.features.j2')
+    pathspec+=(':!dist/tools/template_generator/m4agen/templates/board/Makefile.features.j2')
     pathspec+=(":!*Makefile.features")
 
     git -C "${RIOTBASE}" grep -n "${patterns[@]}" -- "${pathspec[@]}" \
@@ -219,7 +219,7 @@ check_cpu_cpu_model_defined_in_makefile_features() {
     patterns+=(-e '^ *\(export\)\? *CPU_MODEL \??\?=')
     pathspec+=(':!**.md')
     pathspec+=(':!boards/**/Makefile.features')
-    pathspec+=(':!dist/tools/m4a-generator/m4agen/templates/board/Makefile.features.j2')
+    pathspec+=(':!dist/tools/template_generator/m4agen/templates/board/Makefile.features.j2')
     pathspec+=(':!cpu/**/Makefile.features')
 
     git -C "${RIOTBASE}" grep -n "${patterns[@]}" -- "${pathspec[@]}" \


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
There is a bug in static test produced by the changes in #375, because it was not changed some references in `buildsystem_sanity_check`. So with the old template_generator name, it gives a new templates path. This fixed build_sanity_check failures in static-test. 
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
Run static-test
```
make static-test
```
<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references

<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
