### PR TITLE
dist/tools: cppcheck fixes static errors & local running

### DIFF
--- a/dist/tools/cppcheck/check.sh
+++ b/dist/tools/cppcheck/check.sh
@@ -8,7 +8,7 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
+: "${RIOTBASE:="$(cd "$(dirname "$0")/../../../" || exit ; pwd)"}"
 cd $RIOTBASE
 
 : "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
@@ -24,7 +24,17 @@ else
     DEFAULT_SUPPRESSIONS=--suppress="unusedStructMember"
 fi
 
-FILES=""
+# These new changes allows process locally cppcheck tests.
+CODE_FOLDERS="${RIOTBASE}/firmware/    \
+              ${RIOTBASE}/boards/      \
+              ${RIOTBASE}/examples/    \
+              ${RIOTBASE}/tests/       \
+              ${RIOTBASE}/wifi-subsys/"\
+
+# If you want to check only with changed files
+# change this file with
+# FILES=""
+FILES="${CODE_FOLDERS}"
 CPPCHECK_OPTIONS=""
 IN_FILES_SECTION=false
 while [ $# -gt 0 ]; do

--- a/wifi-subsys/components/uart/src/at_handler.c
+++ b/wifi-subsys/components/uart/src/at_handler.c
@@ -50,6 +50,8 @@ char *symbols[4] = {
     "=",
 };
 
+/* cppcheck-suppress constParameter
+     * (reason: <is necessary verify that this data is not null>) */
 int get_symbol(char *command, size_t len, char *output) {
     for (size_t i = 0; i < len; i++) {
         for (size_t j = 0; j < 4; j++) {
@@ -103,7 +105,7 @@ esp_err_t parse_at_message(uint8_t *at_command, at_request_t *output) {
         key2 = strtok(NULL, "+");
     }
 
-    /* cppcheck-suppress nullPointerRedundantCheck
+    /* cppcheck-suppress nullPointer
      * (reason: <is necessary verify that this data is not null>) */
     memcpy(output->key, key_value, strlen(key_value) + 1);
     if (value != NULL) {


### PR DESCRIPTION
<!--
We cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with our coding conventions.
Also keep in mind that your contribution must be understandable to others so DOCUMENTATION is VERY IMPORTANT.
-->

### Contribution description
This contribution adds support to run cppcheck locally, when you run the static-test, you'll see the warnings and cppcheck errors. Note: The cppcheck is configured to only process the code folders as `firmware`, `examples`, `tests`, `wifi-subsys` and `boards`, it's took as reference these folders which could have cpp and c files.
<!--
Description (as detailed as possible) of your contribution.
- Describe the part/s of the code is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can give more information about how to test your changes.
- IMPORTANT! Document your contribution.
-->


### Testing procedure
Run locally static-tests
```
make static-test
```

<!--
### How should your contribution be tested? provide at least the following steps:
- which test, example or piece of code need to be compiled
- Expected output on success or error
-->


### Issues/PRs references
Fixes #379
<!--
Use keywords with the link to the issue you want to resolve, this way some actions can perform automatically, e.g. closing an issue
- If the PR fix an issue: Close, Closes, Fix, Fixes or Resolve
- If the PR is related to another one or issue: see, see also
- If another PR need to be merged before this one: Depend on or Depends on

Examples:
  Fixes #135, see also #135, depends on #135, etc

See more about this feature: https://help.github.com/articles/closing-issues-using-keywords/.
-->
